### PR TITLE
chore: synchronize FMCF Hash Registry for src/app [ref #57]

### DIFF
--- a/hashes/atlas.graph.json
+++ b/hashes/atlas.graph.json
@@ -827,6 +827,41 @@
       "type": "LAYER_DEPENDENCY",
       "impact": "HIGH",
       "reason": "Binds the architectural execution flow directly to the downstream dependency."
+    },
+    {
+      "from": "@root/src/app/issues/page.tsx",
+      "to": "@root/src/app/issues/IssuesClient.tsx",
+      "type": "LAYER_DEPENDENCY",
+      "impact": "HIGH",
+      "reason": "Anchors the Issue Tracker list view to the interactive client component."
+    },
+    {
+      "from": "@root/src/app/issues/[id]/page.tsx",
+      "to": "@root/src/app/issues/[id]/IssueDetailClient.tsx",
+      "type": "LAYER_DEPENDENCY",
+      "impact": "HIGH",
+      "reason": "Anchors the Issue Detail view to the interactive client component."
+    },
+    {
+      "from": "@root/src/app/api/issues/route.ts",
+      "to": "@root/src/app/api/issues/services/issue.ts",
+      "type": "LAYER_DEPENDENCY",
+      "impact": "HIGH",
+      "reason": "Delegates domain logic and database operations to the Issue Service layer."
+    },
+    {
+      "from": "@root/src/app/api/notifications/route.ts",
+      "to": "@root/src/app/api/notifications/services/notification.ts",
+      "type": "LAYER_DEPENDENCY",
+      "impact": "HIGH",
+      "reason": "Delegates domain logic and notification dispatching to the Service layer."
+    },
+    {
+      "from": "@root/src/app/api/profile/route.ts",
+      "to": "@root/src/app/api/profile/schemas/profile.schemas.ts",
+      "type": "LAYER_DEPENDENCY",
+      "impact": "HIGH",
+      "reason": "Enforces DTO validation constraints on profile payloads."
     }
   ]
 }

--- a/hashes/local.map.json
+++ b/hashes/local.map.json
@@ -843,6 +843,190 @@
       "grammar_ref": "@root/hashes/grammar/typescript.hash.md",
       "dependencies": [],
       "fidelity_level": "Active"
+    },
+    "app_api_issues_id_comments_commentId_route": {
+      "file_path": "@root/src/app/api/issues/[id]/comments/[commentId]/route.ts",
+      "hash_reference": "@root/hashes/src/app/api/issues/[id]/comments/[commentId]/route.hash.md",
+      "grammar_ref": "@root/hashes/grammar/typescript.hash.md",
+      "dependencies": [],
+      "fidelity_level": "Active"
+    },
+    "app_api_issues_id_comments_route": {
+      "file_path": "@root/src/app/api/issues/[id]/comments/route.ts",
+      "hash_reference": "@root/hashes/src/app/api/issues/[id]/comments/route.hash.md",
+      "grammar_ref": "@root/hashes/grammar/typescript.hash.md",
+      "dependencies": [],
+      "fidelity_level": "Active"
+    },
+    "app_api_issues_id_route": {
+      "file_path": "@root/src/app/api/issues/[id]/route.ts",
+      "hash_reference": "@root/hashes/src/app/api/issues/[id]/route.hash.md",
+      "grammar_ref": "@root/hashes/grammar/typescript.hash.md",
+      "dependencies": [],
+      "fidelity_level": "Active"
+    },
+    "app_api_issues_id_upvote_route": {
+      "file_path": "@root/src/app/api/issues/[id]/upvote/route.ts",
+      "hash_reference": "@root/hashes/src/app/api/issues/[id]/upvote/route.hash.md",
+      "grammar_ref": "@root/hashes/grammar/typescript.hash.md",
+      "dependencies": [],
+      "fidelity_level": "Active"
+    },
+    "app_api_issues_route": {
+      "file_path": "@root/src/app/api/issues/route.ts",
+      "hash_reference": "@root/hashes/src/app/api/issues/route.hash.md",
+      "grammar_ref": "@root/hashes/grammar/typescript.hash.md",
+      "dependencies": [],
+      "fidelity_level": "Active"
+    },
+    "app_api_issues_services_issue": {
+      "file_path": "@root/src/app/api/issues/services/issue.ts",
+      "hash_reference": "@root/hashes/src/app/api/issues/services/issue.hash.md",
+      "grammar_ref": "@root/hashes/grammar/typescript.hash.md",
+      "dependencies": [],
+      "fidelity_level": "Active"
+    },
+    "app_api_notifications_id_route": {
+      "file_path": "@root/src/app/api/notifications/[id]/route.ts",
+      "hash_reference": "@root/hashes/src/app/api/notifications/[id]/route.hash.md",
+      "grammar_ref": "@root/hashes/grammar/typescript.hash.md",
+      "dependencies": [],
+      "fidelity_level": "Active"
+    },
+    "app_api_notifications_count_route": {
+      "file_path": "@root/src/app/api/notifications/count/route.ts",
+      "hash_reference": "@root/hashes/src/app/api/notifications/count/route.hash.md",
+      "grammar_ref": "@root/hashes/grammar/typescript.hash.md",
+      "dependencies": [],
+      "fidelity_level": "Active"
+    },
+    "app_api_notifications_route": {
+      "file_path": "@root/src/app/api/notifications/route.ts",
+      "hash_reference": "@root/hashes/src/app/api/notifications/route.hash.md",
+      "grammar_ref": "@root/hashes/grammar/typescript.hash.md",
+      "dependencies": [],
+      "fidelity_level": "Active"
+    },
+    "app_api_notifications_seen_route": {
+      "file_path": "@root/src/app/api/notifications/seen/route.ts",
+      "hash_reference": "@root/hashes/src/app/api/notifications/seen/route.hash.md",
+      "grammar_ref": "@root/hashes/grammar/typescript.hash.md",
+      "dependencies": [],
+      "fidelity_level": "Active"
+    },
+    "app_api_notifications_services_notification": {
+      "file_path": "@root/src/app/api/notifications/services/notification.ts",
+      "hash_reference": "@root/hashes/src/app/api/notifications/services/notification.hash.md",
+      "grammar_ref": "@root/hashes/grammar/typescript.hash.md",
+      "dependencies": [],
+      "fidelity_level": "Active"
+    },
+    "app_api_releases_route": {
+      "file_path": "@root/src/app/api/releases/route.ts",
+      "hash_reference": "@root/hashes/src/app/api/releases/route.hash.md",
+      "grammar_ref": "@root/hashes/grammar/typescript.hash.md",
+      "dependencies": [],
+      "fidelity_level": "Active"
+    },
+    "app_api_users_account_route": {
+      "file_path": "@root/src/app/api/users/account/route.ts",
+      "hash_reference": "@root/hashes/src/app/api/users/account/route.hash.md",
+      "grammar_ref": "@root/hashes/grammar/typescript.hash.md",
+      "dependencies": [],
+      "fidelity_level": "Active"
+    },
+    "app_api_users_search_route": {
+      "file_path": "@root/src/app/api/users/search/route.ts",
+      "hash_reference": "@root/hashes/src/app/api/users/search/route.hash.md",
+      "grammar_ref": "@root/hashes/grammar/typescript.hash.md",
+      "dependencies": [],
+      "fidelity_level": "Active"
+    },
+    "app_api_users_services_user": {
+      "file_path": "@root/src/app/api/users/services/user.ts",
+      "hash_reference": "@root/hashes/src/app/api/users/services/user.hash.md",
+      "grammar_ref": "@root/hashes/grammar/typescript.hash.md",
+      "dependencies": [],
+      "fidelity_level": "Active"
+    },
+    "app_globals_css": {
+      "file_path": "@root/src/app/globals.css",
+      "hash_reference": "@root/hashes/src/app/globals.css.hash.md",
+      "grammar_ref": "@root/hashes/grammar/typescript.hash.md",
+      "dependencies": [],
+      "fidelity_level": "Active"
+    },
+    "app_issues_IssuesClient": {
+      "file_path": "@root/src/app/issues/IssuesClient.tsx",
+      "hash_reference": "@root/hashes/src/app/issues/IssuesClient.hash.md",
+      "grammar_ref": "@root/hashes/grammar/typescript.hash.md",
+      "dependencies": [],
+      "fidelity_level": "Active"
+    },
+    "app_issues_id_IssueDetailClient": {
+      "file_path": "@root/src/app/issues/[id]/IssueDetailClient.tsx",
+      "hash_reference": "@root/hashes/src/app/issues/[id]/IssueDetailClient.hash.md",
+      "grammar_ref": "@root/hashes/grammar/typescript.hash.md",
+      "dependencies": [],
+      "fidelity_level": "Active"
+    },
+    "app_issues_id_page": {
+      "file_path": "@root/src/app/issues/[id]/page.tsx",
+      "hash_reference": "@root/hashes/src/app/issues/[id]/page.hash.md",
+      "grammar_ref": "@root/hashes/grammar/typescript.hash.md",
+      "dependencies": [],
+      "fidelity_level": "Active"
+    },
+    "app_issues_page": {
+      "file_path": "@root/src/app/issues/page.tsx",
+      "hash_reference": "@root/hashes/src/app/issues/page.hash.md",
+      "grammar_ref": "@root/hashes/grammar/typescript.hash.md",
+      "dependencies": [],
+      "fidelity_level": "Active"
+    },
+    "app_releases_feed_xml_route": {
+      "file_path": "@root/src/app/releases/feed.xml/route.ts",
+      "hash_reference": "@root/hashes/src/app/releases/feed.xml/route.hash.md",
+      "grammar_ref": "@root/hashes/grammar/typescript.hash.md",
+      "dependencies": [],
+      "fidelity_level": "Active"
+    },
+    "app_api_lib_errors_services": {
+      "file_path": "@root/src/app/api/_lib/errors/services.ts",
+      "hash_reference": "@root/hashes/src/app/api/_lib/errors/services.hash.md",
+      "grammar_ref": "@root/hashes/grammar/typescript.hash.md",
+      "dependencies": [],
+      "fidelity_level": "Active"
+    },
+    "app_api_issues": {
+      "file_path": "@root/src/app/api/issues/",
+      "hash_reference": "@root/hashes/src/app/api/issues.hash.md",
+      "grammar_ref": "@root/hashes/grammar/typescript.hash.md",
+      "dependencies": [],
+      "fidelity_level": "Active"
+    },
+    "app_api_notifications": {
+      "file_path": "@root/src/app/api/notifications/",
+      "hash_reference": "@root/hashes/src/app/api/notifications.hash.md",
+      "grammar_ref": "@root/hashes/grammar/typescript.hash.md",
+      "dependencies": [],
+      "fidelity_level": "Active"
+    },
+    "app_api_profile_route": {
+      "file_path": "@root/src/app/api/profile/route.ts",
+      "hash_reference": "@root/hashes/src/app/api/profile/route.hash.md",
+      "grammar_ref": "@root/hashes/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/src/app/api/profile/schemas/profile.schemas.ts"
+      ],
+      "fidelity_level": "Active"
+    },
+    "app_api_profile_schemas_profile_schemas": {
+      "file_path": "@root/src/app/api/profile/schemas/profile.schemas.ts",
+      "hash_reference": "@root/hashes/src/app/api/profile/schemas/profile.schemas.hash.md",
+      "grammar_ref": "@root/hashes/grammar/typescript.hash.md",
+      "dependencies": [],
+      "fidelity_level": "Active"
     }
   }
 }

--- a/hashes/src/app/about/page.hash.md
+++ b/hashes/src/app/about/page.hash.md
@@ -1,29 +1,22 @@
 ---
-State_ID: BigInt(0x2)
+State_ID: BigInt(0x0fc98e6)
 Git_SHA: LATEST
-Grammar_Lock: "@root/hashes/grammar/next.hash.md"
+Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
 ---
 
-## @Route.About
-
-### [Routes]
-| Handler | Description |
-|---------|-------------|
-| `page.tsx` | About page with app description |
+## @About.Page
 
 ### [Signatures]
-```tsx
+```ts
 export default function AboutPage(): JSX.Element
 ```
 
 ### [Governance]
-- **UI_Law:** Full-page hero with background image from `@/assets`.
-- **I18n_Law:** All text content via `useI18n()`.
-- **Action_Law:** CTA buttons link to `/chat` and GitHub repo.
+- **Brand_Atmosphere_Sync:** Mandates the use of thematic San Juan hero imagery and specific primary-to-accent gradients to maintain visual continuity with the landing experience.
+- **Motion_Entrance_Law:** Enforces standard entrance animations via `framer-motion` for all content sections.
 
 ### [Semantic Hash]
-Public about page at `/about` showcasing app mission, description, and call-to-action.
+The UI boundary for the platform's vision and background. it provides a high-fidelity narrative layout, localized via the I18n provider, explaining the "why" behind PR\\AI.
 
 ### [Linkage]
-- **Upstream:** `Header`, `Footer` components, `useI18n`
-- **Downstream:** Chat page, GitHub repo
+- **Dependencies:** `@/lib/effect/I18nProvider`, `framer-motion`, `next/image`

--- a/hashes/src/app/api/_lib/errors/services.hash.md
+++ b/hashes/src/app/api/_lib/errors/services.hash.md
@@ -1,0 +1,25 @@
+---
+State_ID: BigInt(0x0fc98ec)
+Git_SHA: LATEST
+Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
+---
+
+## @Api.ServiceErrors
+
+### [Signatures]
+```ts
+export class IssueDbError extends Data.TaggedError("IssueDbError")
+export class NotificationDbError extends Data.TaggedError("NotificationDbError")
+export class UsersDbError extends Data.TaggedError("UsersDbError")
+export class ChatDbError extends Data.TaggedError("ChatDbError")
+export class AccountDbError extends Data.TaggedError("AccountDbError")
+```
+
+### [Governance]
+- **Tagged_Error_Schema:** Mandates the use of `Effect.Data.TaggedError` for all backend service failures to enable exhaustive pattern matching and type-safe error propagation.
+
+### [Semantic Hash]
+The definition layer for service-level failure modes. It provides a unified set of tagged objects used as the error channel for all database-driven effect programs across the API.
+
+### [Linkage]
+- **Dependencies:** `effect`

--- a/hashes/src/app/api/build-info/route.hash.md
+++ b/hashes/src/app/api/build-info/route.hash.md
@@ -1,24 +1,21 @@
 ---
-State_ID: BigInt(0x3)
+State_ID: BigInt(0x0fc98e7)
 Git_SHA: LATEST
-Grammar_Lock: "@root/hashes/grammar/next.hash.md"
+Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
 ---
 
-## @Route.BuildInfo
+## @Route.Api.BuildInfo
 
 ### [Signatures]
 ```ts
-export async function GET(request: NextRequest): Promise<NextResponse>
+export async function GET(): Promise<NextResponse>
 ```
 
 ### [Governance]
-- **ForceStatic_Law:** Route is `force-static`. Response is cached by Next.js at the edge.
-- **ServerOnly_Law:** Uses `fs/promises` — server-side only.
-- **Fallback_Law:** Returns `{ buildHash: 'dev' }` if `public/app-version.json` cannot be read (e.g., during `next dev`).
+- **Process_Env_Bridge:** Directly exposes critical build-time environment variables (commit SHA, timestamp) to the client for debugging and version tracking.
 
 ### [Semantic Hash]
-API route that reads the app version hash from `public/app-version.json` (written by `scripts/generate-app-version.mjs` post-build). Returns first 12 chars of the SHA-256 hash.
+The diagnostic boundary for the application's deployment state. It serves as an internal health and version check, providing transparency into the current running build.
 
 ### [Linkage]
-- **Upstream:** `public/app-version.json` (written by post-build script)
-- **Downstream:** `@root/src/lib/effect/hooks/useBuildInfo.ts`, `@root/src/components/layout/Header.tsx`
+- **Dependencies:** `process.env`

--- a/hashes/src/app/api/issues.hash.md
+++ b/hashes/src/app/api/issues.hash.md
@@ -1,0 +1,13 @@
+---
+State_ID: BigInt(0x0fc98ed)
+Git_SHA: LATEST
+Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
+---
+
+## @Api.Issues.Module
+
+### [Semantic Hash]
+The architectural boundary for all Issue Tracker backend operations. It encapsulates community reporting, upvoting, and commenting systems, serving as a unified gateway for collaborative feedback.
+
+### [Governance]
+- **Domain_Sovereignty_Issues:** Establishes the `issues` namespace as the source of truth for all peer-to-peer reporting logic and community prioritization.

--- a/hashes/src/app/api/issues/[id]/comments/[commentId]/route.hash.md
+++ b/hashes/src/app/api/issues/[id]/comments/[commentId]/route.hash.md
@@ -1,0 +1,24 @@
+---
+State_ID: BigInt(0x0fc98d5)
+Git_SHA: LATEST
+Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
+---
+
+## @Route.Api.Issues.Comments.Edit
+
+### [Signatures]
+```ts
+export async function PATCH(request: NextRequest, { params }): Promise<NextResponse>
+export async function DELETE(request: NextRequest, { params }): Promise<NextResponse>
+```
+
+### [Governance]
+- **Ownership_Hard_Lock:** Restricts comment edits strictly to the original author via ID verification in the implementation logic.
+- **Soft_Delete_Law:** Implements comment removal as a `deleted_at` timestamp update to maintain reference integrity within the notification system.
+- **Validation_Hard_Lock:** Enforces `ParamsSchema` and `CommentBodySchema` decoding to prevent malformed updates.
+
+### [Semantic Hash]
+The management interface for existing comments. It provides secure paths for authors to update their feedback and for both authors and admins to perform non-destructive deletions.
+
+### [Linkage]
+- **Dependencies:** `@/app/api/issues/services/issue`, `@/app/api/_lib/validation`, `@/lib/supabase/server`

--- a/hashes/src/app/api/issues/[id]/comments/route.hash.md
+++ b/hashes/src/app/api/issues/[id]/comments/route.hash.md
@@ -1,0 +1,23 @@
+---
+State_ID: BigInt(0x0fc98d4)
+Git_SHA: LATEST
+Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
+---
+
+## @Route.Api.Issues.Comments
+
+### [Signatures]
+```ts
+export async function POST(request: NextRequest, { params }): Promise<NextResponse>
+```
+
+### [Governance]
+- **Auth_Gate_POST:** Mandates a verified user session through `@/lib/supabase/server` before allowing comment ingestion.
+- **Admin_Reflex_Rule:** Determines `is_admin_reply` status by fetching the actor's profile visibility, ensuring authoritative labeling in the UI.
+- **Mention_Reflex_Rule:** Indirectly triggers asynchronous mention dispatching via the `issueService` upon successful insertion.
+
+### [Semantic Hash]
+The write-only boundary for issue discussions. It facilitates the creation of a new comment, ensuring proper attribution and triggering the notification ecosystem for mentioned users.
+
+### [Linkage]
+- **Dependencies:** `@/app/api/issues/services/issue`, `@/app/api/_lib/validation`, `@/lib/supabase/server`

--- a/hashes/src/app/api/issues/[id]/route.hash.md
+++ b/hashes/src/app/api/issues/[id]/route.hash.md
@@ -1,0 +1,25 @@
+---
+State_ID: BigInt(0x0fc98d3)
+Git_SHA: LATEST
+Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
+---
+
+## @Route.Api.Issues.Detail
+
+### [Signatures]
+```ts
+export async function GET(request: NextRequest, { params }): Promise<NextResponse>
+export async function PATCH(request: NextRequest, { params }): Promise<NextResponse>
+export async function DELETE(request: NextRequest, { params }): Promise<NextResponse>
+```
+
+### [Governance]
+- **Effect_Silo_Pattern:** Wraps granular entity retrieval and modification within `Effect` to maintain predictable error states.
+- **Admin_Reflex_Rule:** Permits issue deletion only to the original author or a verified administrator, enforcing strict access control.
+- **Validation_Hard_Lock:** Standardizes URI parameter and body validation through `@/app/api/_lib/validation`.
+
+### [Semantic Hash]
+The authoritative endpoint for single-issue operations. It manages the lifecycle of a specific report, including fetching deep metadata (comments, author details) and handling authorized state changes or removals.
+
+### [Linkage]
+- **Dependencies:** `@/app/api/issues/services/issue`, `@/app/api/_lib/validation`, `@/app/api/_lib/response`, `@/lib/supabase/server`

--- a/hashes/src/app/api/issues/[id]/upvote/route.hash.md
+++ b/hashes/src/app/api/issues/[id]/upvote/route.hash.md
@@ -1,0 +1,22 @@
+---
+State_ID: BigInt(0x0fc98d6)
+Git_SHA: LATEST
+Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
+---
+
+## @Route.Api.Issues.Upvote
+
+### [Signatures]
+```ts
+export async function POST(request: NextRequest, { params }): Promise<NextResponse>
+```
+
+### [Governance]
+- **Toggle_Atomic_Lock:** Wraps the check-then-insert/delete logic within a single `issueService` call to ensure idempotent upvote states.
+- **Auth_Gate_POST:** Strictly requires a valid user session, preventing anonymous upvoting.
+
+### [Semantic Hash]
+The interaction endpoint for community upvoting. It allows authenticated users to express interest in specific issues, serving as a primary driver for report prioritization.
+
+### [Linkage]
+- **Dependencies:** `@/app/api/issues/services/issue`, `@/app/api/_lib/validation`, `@/lib/supabase/server`

--- a/hashes/src/app/api/issues/route.hash.md
+++ b/hashes/src/app/api/issues/route.hash.md
@@ -1,0 +1,24 @@
+---
+State_ID: BigInt(0x0fc98d1)
+Git_SHA: LATEST
+Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
+---
+
+## @Route.Api.Issues
+
+### [Signatures]
+```ts
+export async function GET(request: NextRequest): Promise<NextResponse>
+export async function POST(request: NextRequest): Promise<NextResponse>
+```
+
+### [Governance]
+- **Effect_Silo_Pattern:** Mandates the wrapping of all business logic and service calls within `Effect` programs to ensure explicit error handling and side-effect management.
+- **Validation_Hard_Lock:** Strictly enforces Schema-based decoding for all incoming data (search params and request bodies) via `@/app/api/_lib/validation`.
+- **Auth_Gate_POST:** Prevents unauthenticated issue creation by requiring a valid Supabase user session before delegating to the `issueService`.
+
+### [Semantic Hash]
+The main REST boundary for collective issue operations. It serves as a secure, validated gateway for retrieving filtered lists of community reports and submitting new feedback into the system.
+
+### [Linkage]
+- **Dependencies:** `./services/issue`, `@/app/api/_lib/validation`, `@/app/api/_lib/response`, `@/lib/supabase/server`, `effect`

--- a/hashes/src/app/api/issues/services/issue.hash.md
+++ b/hashes/src/app/api/issues/services/issue.hash.md
@@ -1,0 +1,27 @@
+---
+State_ID: BigInt(0x0fc98d2)
+Git_SHA: LATEST
+Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
+---
+
+## @Issues.Service
+
+### [Signatures]
+```ts
+export const issueService = {
+  listIssues, createIssue, getIssueById, updateIssue, deleteIssue,
+  addComment, updateComment, deleteComment, dispatchMentionNotifications,
+  searchProfiles, toggleUpvote, getProfile
+}
+```
+
+### [Governance]
+- **Atomic_Database_Gate:** Mandates standardizing all Supabase CRUD operations within `Effect.tryPromise` to ensure consistent error mapping to `IssueDbError`.
+- **Soft_Delete_Law:** Enforces a "Deleted At" timestamp pattern for comments, preserving mention metadata and system integrity while removing content from active visibility.
+- **Mention_Reflex_Rule:** Orchestrates non-blocking asynchronous mention detection and notification dispatch using `Effect.runFork` during insertion events.
+
+### [Semantic Hash]
+The architectural core for Issue Tracker persistence and logic. It centralizes all domain-specific Postgres interactions, permission validations, and cross-module notification triggers, ensuring a unified and predictable state across the API layer.
+
+### [Linkage]
+- **Dependencies:** `effect`, `@/lib/supabase/server`, `@/app/api/_lib/validation/common`, `@/app/api/_lib/errors/services`

--- a/hashes/src/app/api/notifications.hash.md
+++ b/hashes/src/app/api/notifications.hash.md
@@ -1,0 +1,13 @@
+---
+State_ID: BigInt(0x0fc98ee)
+Git_SHA: LATEST
+Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
+---
+
+## @Api.Notifications.Module
+
+### [Semantic Hash]
+The architectural boundary for the platform's alerts and real-time events. It manages mention detection, read-state persistence, and asynchronous dispatching for all user notifications.
+
+### [Governance]
+- **Domain_Sovereignty_Notifications:** Establishes the `notifications` namespace as the authoritative handler for user engagement alerts and activity tracking.

--- a/hashes/src/app/api/notifications/[id]/route.hash.md
+++ b/hashes/src/app/api/notifications/[id]/route.hash.md
@@ -1,0 +1,22 @@
+---
+State_ID: BigInt(0x0fc98da)
+Git_SHA: LATEST
+Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
+---
+
+## @Route.Api.Notifications.Detail
+
+### [Signatures]
+```ts
+export async function PATCH(request: NextRequest, { params }): Promise<NextResponse>
+```
+
+### [Governance]
+- **Granular_Read_Law:** Allows for the marking of an individual notification as read, ensuring precise state control for the user's focus.
+- **Validation_Hard_Lock:** Standardizes URI parameter decoding via `UuidSchema` and `@/app/api/_lib/validation`.
+
+### [Semantic Hash]
+The targeted boundary for a single notification's lifecycle. It facilitates the state transition of a specific alert from unread to read, typically triggered by a user's direct interaction.
+
+### [Linkage]
+- **Dependencies:** `@/lib/supabase/server`, `@/app/api/notifications/services/notification`, `@/app/api/_lib/validation`

--- a/hashes/src/app/api/notifications/count/route.hash.md
+++ b/hashes/src/app/api/notifications/count/route.hash.md
@@ -1,0 +1,21 @@
+---
+State_ID: BigInt(0x0fc98d8)
+Git_SHA: LATEST
+Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
+---
+
+## @Route.Api.Notifications.Count
+
+### [Signatures]
+```ts
+export async function GET(): Promise<NextResponse>
+```
+
+### [Governance]
+- **Performance_Isolation_Law:** Maintains a dedicated, high-performance endpoint for unread counts to prevent pagination logic from bloating the badge update lifecycle.
+
+### [Semantic Hash]
+A specialized utility endpoint for the notification badge. It returns a precise integer of unread notifications, ensuring the UI accurately reflects the user's pending alerts.
+
+### [Linkage]
+- **Dependencies:** `@/lib/supabase/server`, `@/app/api/notifications/services/notification`

--- a/hashes/src/app/api/notifications/route.hash.md
+++ b/hashes/src/app/api/notifications/route.hash.md
@@ -1,0 +1,23 @@
+---
+State_ID: BigInt(0x0fc98d7)
+Git_SHA: LATEST
+Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
+---
+
+## @Route.Api.Notifications
+
+### [Signatures]
+```ts
+export async function GET(): Promise<NextResponse>
+export async function PATCH(): Promise<NextResponse>
+```
+
+### [Governance]
+- **Auth_Gate_GET:** Strictly enforces a valid Supabase session before allowing access to the notification feed.
+- **RPC_Sovereignty:** Delegates all data retrieval and batch updates to vetted database RPCs (`get_notifications`, `mark_notifications_read`) for performance and integrity.
+
+### [Semantic Hash]
+The main controller for the Notification system. It manages the retrieval of paginated events and provides a bulk action for marking all notifications as read.
+
+### [Linkage]
+- **Dependencies:** `@/lib/supabase/server`, `@/app/api/notifications/services/notification`, `effect`

--- a/hashes/src/app/api/notifications/seen/route.hash.md
+++ b/hashes/src/app/api/notifications/seen/route.hash.md
@@ -1,0 +1,21 @@
+---
+State_ID: BigInt(0x0fc98d9)
+Git_SHA: LATEST
+Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
+---
+
+## @Route.Api.Notifications.Seen
+
+### [Signatures]
+```ts
+export async function POST(): Promise<NextResponse>
+```
+
+### [Governance]
+- **Non_Destructive_Seen_Law:** Marks a batch of notifications as "seen" (clearing temporary UI highlights/badges) without transitioning their full state to "read."
+
+### [Semantic Hash]
+The interaction endpoint for the notification panel opening. It ensures that the system tracks which alerts have been viewed by the user, facilitating a clean and less intrusive notification experience.
+
+### [Linkage]
+- **Dependencies:** `@/lib/supabase/server`, `@/app/api/notifications/services/notification`

--- a/hashes/src/app/api/notifications/services/notification.hash.md
+++ b/hashes/src/app/api/notifications/services/notification.hash.md
@@ -1,0 +1,21 @@
+---
+State_ID: BigInt(0x0fc98db)
+Git_SHA: LATEST
+Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
+---
+
+## @Notifications.Service
+
+### [Signatures]
+```ts
+export class NotificationDbError extends Error
+```
+
+### [Governance]
+- **Error_Schema_Consistency:** Enforces a standardized error shape for all notification-related database failures to maintain predictability across the API layer.
+
+### [Semantic Hash]
+The definition layer for notification-specific error handling. It ensures that database anomalies are surfaced with consistent metadata and types.
+
+### [Linkage]
+- **Dependencies:** `@/app/api/_lib/errors/services`

--- a/hashes/src/app/api/profile/route.hash.md
+++ b/hashes/src/app/api/profile/route.hash.md
@@ -1,34 +1,13 @@
----
-State_ID: BigInt(0x0)
-Git_SHA: LATEST
-Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
----
+# Contract: src/app/api/profile/route.ts
+- **Signature**: `app_api_profile_route`
+- **Role**: Profile management API.
 
-## @Route.Profile
+## Linkage
+- **Grammar**: [typescript.hash.md](file:///Users/chrismperez/Desktop/chris-projects/prai/hashes/grammar/typescript.hash.md)
+- **Dependencies**:
+  - `next/server`
+  - `@supabase/ssr`
+  - `./schemas`
 
-### [Routes]
-| Method | Handler | Description |
-|--------|---------|-------------|
-| PATCH | `PATCH` | Update user profile |
-
-### [Signatures]
-```ts
-export async function PATCH(request: NextRequest): Promise<NextResponse>
-```
-
-### [Governance]
-- **Schema_Law:** Input validated via `UpdateProfileSchema` from `./schemas`.
-- **Response_Law:** Uses `exitResponse` helper for Effect → NextResponse conversion.
-- **Validation_Law:** Rejects requests with no valid update fields.
-
-### [Implementation Notes]
-- **PATCH:** Updates profile fields (display_name, bio, language) via Supabase.
-- **Validation:** Returns `ValidationError` if no valid fields provided.
-- **RLS:** Uses server-side Supabase client with service role key.
-
-### [Semantic Hash]
-API route for user profile updates. Accepts partial updates for display_name, bio, and language fields.
-
-### [Linkage]
-- **Upstream:** `@/app/api/_lib/validation`, `@/app/api/_lib/response`
-- **Downstream:** Profile component (`src/app/profile/`)
+## Architectural Hash
+- Logic: GET and PATCH for profile data. Secure via Supabase session.

--- a/hashes/src/app/api/profile/schemas/profile.schemas.hash.md
+++ b/hashes/src/app/api/profile/schemas/profile.schemas.hash.md
@@ -1,25 +1,11 @@
----
-State_ID: BigInt(0x0)
-Git_SHA: LATEST
-Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
----
+# Contract: src/app/api/profile/schemas/profile.schemas.ts
+- **Signature**: `app_api_profile_schemas_profile_schemas`
+- **Role**: Profile validation schemas.
 
-## @Lib.Api.Profile.Schemas
+## Linkage
+- **Grammar**: [typescript.hash.md](file:///Users/chrismperez/Desktop/chris-projects/prai/hashes/grammar/typescript.hash.md)
+- **Dependencies**:
+  - `effect/Schema`
 
-### [Signatures]
-```ts
-export const SupportedLanguageSchema: Schema<"en" | "es">
-export const UpdateProfileSchema: Schema<{ userId: string; display_name?: string; bio?: string; language?: Locale }>
-```
-
-### [Governance]
-- **Schema_Law:** Profile updates validated against `UpdateProfileSchema`.
-- **Language_Law:** Only `en` and `es` locales are supported.
-- **Required_Law:** `userId` is required; other fields are optional.
-
-### [Semantic Hash]
-Effect-TS schemas for profile update requests.
-
-### [Linkage]
-- **Upstream:** `@/app/api/_lib/validation`
-- **Downstream:** `src/app/api/profile/route.ts`
+## Architectural Hash
+- Logic: Structure and validation rules for profile payloads.

--- a/hashes/src/app/api/releases/route.hash.md
+++ b/hashes/src/app/api/releases/route.hash.md
@@ -1,0 +1,21 @@
+---
+State_ID: BigInt(0x0fc98df)
+Git_SHA: LATEST
+Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
+---
+
+## @Route.Api.Releases
+
+### [Signatures]
+```ts
+export async function GET(): Promise<NextResponse>
+```
+
+### [Governance]
+- **Changelog_Service_Bridge:** Exposes versioning and update metadata by bridging the `Changelog` service to a public HTTP interface with strict 1-hour cache headers.
+
+### [Semantic Hash]
+The public metadata boundary for application updates. It serves the most recent release notes and version history, enabling chronos-aware client features.
+
+### [Linkage]
+- **Dependencies:** `@/lib/effect/services/Changelog`, `@/app/api/_lib/constants/status-codes`

--- a/hashes/src/app/api/users/account/route.hash.md
+++ b/hashes/src/app/api/users/account/route.hash.md
@@ -1,0 +1,22 @@
+---
+State_ID: BigInt(0x0fc98dd)
+Git_SHA: LATEST
+Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
+---
+
+## @Route.Api.Users.DeleteAccount
+
+### [Signatures]
+```ts
+export async function DELETE(request: NextRequest): Promise<NextResponse>
+```
+
+### [Governance]
+- **Account_Deletion_Hard_Lock:** Mandates a `confirmHandle` match in the request body as a secondary safety gate before executing destructive service deletions.
+- **Auth_Gate_DELETE:** Strictly requires a fresh Supabase user session to protect account integrity.
+
+### [Semantic Hash]
+The destructive boundary for user offboarding. It validates the user's intent through a handle-match confirmation and triggers the multi-layer cascade deletion service.
+
+### [Linkage]
+- **Dependencies:** `@/app/api/users/services/user`, `@/app/api/_lib/validation/common`, `@/lib/supabase/server`, `@/app/api/_lib/constants/status-codes`

--- a/hashes/src/app/api/users/search/route.hash.md
+++ b/hashes/src/app/api/users/search/route.hash.md
@@ -1,0 +1,22 @@
+---
+State_ID: BigInt(0x0fc98dc)
+Git_SHA: LATEST
+Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
+---
+
+## @Route.Api.Users.Search
+
+### [Signatures]
+```ts
+export async function GET(request: NextRequest): Promise<NextResponse>
+```
+
+### [Governance]
+- **Auth_Gate_GET:** Mandates a valid user session before allowing cross-profile discovery to prevent anonymous scraping.
+- **RPC_Sovereignty:** Offloads the complex ILIKE and distance-based searching to the `search_users` database RPC for optimal performance.
+
+### [Semantic Hash]
+The discovery boundary for the PR\\AI community. It supports fuzzy handle/name searching with built-in pagination, enabling features like @mentions and profile lookup.
+
+### [Linkage]
+- **Dependencies:** `@/lib/supabase/server`, `@/app/api/_lib/validation`, `@/app/api/_lib/errors`

--- a/hashes/src/app/api/users/services/user.hash.md
+++ b/hashes/src/app/api/users/services/user.hash.md
@@ -1,0 +1,23 @@
+---
+State_ID: BigInt(0x0fc98de)
+Git_SHA: LATEST
+Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
+---
+
+## @Users.Service
+
+### [Signatures]
+```ts
+export const userService = { deleteAccount }
+const deleteUserData = async (userId: string): Promise<void>
+```
+
+### [Governance]
+- **Cascade_Delete_Law:** Orchestrates the surgical removal of all user-associated data (chats, issues, upvotes, notifications) using the Service Role key to override RLS for complete cleanup.
+- **Auth_Admin_Bridge:** Directly communicates with `supabase.auth.admin` to purge the identity record after all application-level data has been erased.
+
+### [Semantic Hash]
+The administrative engine for user data management. It handles complex, multi-table deletions with elevated privileges to ensure full data erasure upon account closure.
+
+### [Linkage]
+- **Dependencies:** `effect`, `@supabase/supabase-js`, `@/app/api/_lib/validation/common`, `@/app/api/_lib/errors/services`

--- a/hashes/src/app/globals.css.hash.md
+++ b/hashes/src/app/globals.css.hash.md
@@ -1,0 +1,18 @@
+---
+State_ID: BigInt(0x0fc98e4)
+Git_SHA: LATEST
+Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
+---
+
+## @App.Globals.Css
+
+### [Governance]
+- **Tailwind_Core_Integration:** Mandates the base inclusion of Tailwind layers (base, components, utilities) as the primary styling engine.
+- **Brand_Variables_Lock:** Enforces the use of CSS variables for core colors (`primary`, `accent`, `background`) to enable platform-wide thematic consistency.
+- **Z_Index_Hierarchy:** Standardizes the layering order for modals, headers, and backgrounds to prevent occlusion conflicts.
+
+### [Semantic Hash]
+The global stylesheet for PR\\AI. It defines the foundational layout, typography, and color tokens used across all client components, serving as the source of truth for the application's visual system.
+
+### [Linkage]
+- **Dependencies:** `tailwindcss`

--- a/hashes/src/app/issues/IssuesClient.hash.md
+++ b/hashes/src/app/issues/IssuesClient.hash.md
@@ -1,0 +1,24 @@
+---
+State_ID: BigInt(0x0fc98cd)
+Git_SHA: LATEST
+Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
+---
+
+## @Issues.IssuesClient
+
+### [Signatures]
+```ts
+export function IssuesPage(): JSX.Element
+const IssueList = Object.assign(IssueListRoot, { Filters, Items, Card, NewForm })
+```
+
+### [Governance]
+- **Matrix_UI_Lock:** Enforces a persistent background glow and layout structure using `framer-motion` and `lucide-react` for brand consistency.
+- **State_Silo_Pattern:** Orchestrates all issue operations (fetch, creation, upvoting) exclusively through `issuesSlice` to ensure decoupled state management.
+- **I18n_Boundary:** Strictly mandates the use of `useI18n()` for all human-readable strings to support multi-language scalability.
+
+### [Semantic Hash]
+The main controller for the Issue Tracker interface. It provides a cohesive UI for reporting, filtering, and interacting with community feedback while maintaining the application's premium aesthetic.
+
+### [Linkage]
+- **Dependencies:** `framer-motion`, `lucide-react`, `@/store/slices/issuesSlice`, `@/lib/effect/I18nProvider`, `@/contexts/AuthContext`, `@/components/layout/Header`, `@/components/layout/Footer`

--- a/hashes/src/app/issues/[id]/IssueDetailClient.hash.md
+++ b/hashes/src/app/issues/[id]/IssueDetailClient.hash.md
@@ -1,0 +1,23 @@
+---
+State_ID: BigInt(0x0fc98cf)
+Git_SHA: LATEST
+Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
+---
+
+## @Issues.IssueDetailClient
+
+### [Signatures]
+```ts
+export function IssueDetailClient({ id }: { id: string }): JSX.Element
+```
+
+### [Governance]
+- **Detail_Context_Lock:** Manages individual issue lifecycle (loading, errors, detail fetching) through `issuesSlice` anchored to a specific `id`.
+- **Comment_Optimism_Law:** Strictly implements optimistic UI updates for all comment actions (add, update, delete) to ensure a high-fidelity, zero-latency interaction model.
+- **Admin_Sovereignty:** Restricts destructive actions (Issue deletion, Status modification) to authenticated administrators or the verified original author.
+
+### [Semantic Hash]
+The dedicated resolution workspace for individual issues. It enables community-driven feedback through optimistic commenting and upvoting while maintaining a clean, markdown-supported discussion thread.
+
+### [Linkage]
+- **Dependencies:** `@/store/slices/issuesSlice`, `markdown-it`, `framer-motion`, `lucide-react`, `@/lib/effect/I18nProvider`, `@/contexts/AuthContext`

--- a/hashes/src/app/issues/[id]/page.hash.md
+++ b/hashes/src/app/issues/[id]/page.hash.md
@@ -1,0 +1,22 @@
+---
+State_ID: BigInt(0x0fc98d0)
+Git_SHA: LATEST
+Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
+---
+
+## @Route.Issues.Detail
+
+### [Signatures]
+```ts
+export const metadata: Metadata
+export default async function IssueDetailRoute({ params }): JSX.Element
+```
+
+### [Governance]
+- **Dynamic_Route_Law:** Orchestrates the asynchronous extraction of `id` parameters to mount the `IssueDetailClient` within the specific issue boundary.
+
+### [Semantic Hash]
+The route boundary for detailed issue views. It manages page-level identity and ensures the correct entity ID is propagated to the interaction layer.
+
+### [Linkage]
+- **Dependencies:** `@/app/issues/[id]/IssueDetailClient`

--- a/hashes/src/app/issues/page.hash.md
+++ b/hashes/src/app/issues/page.hash.md
@@ -1,0 +1,22 @@
+---
+State_ID: BigInt(0x0fc98ce)
+Git_SHA: LATEST
+Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
+---
+
+## @Route.Issues
+
+### [Signatures]
+```ts
+export const metadata: Metadata
+export default function IssuesRoute(): JSX.Element
+```
+
+### [Governance]
+- **Entry_Point_Law:** Serves as the primary entry point for the `/issues` route, aggregating SEO metadata and rendering the `IssuesPage` client component.
+
+### [Semantic Hash]
+The route boundary for the global Issue Tracker. It defines the page-level SEO and ensures the client-side interaction layer is properly mounted.
+
+### [Linkage]
+- **Dependencies:** `@/app/issues/IssuesClient`

--- a/hashes/src/app/legal/cookies/page.hash.md
+++ b/hashes/src/app/legal/cookies/page.hash.md
@@ -1,26 +1,22 @@
 ---
-State_ID: BigInt(0xe4281d08)
-Git_SHA: e14bd7ccd7a813335a9fa967470e8061bd2124a0
+State_ID: BigInt(0x0fc98e3)
+Git_SHA: LATEST
 Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
 ---
 
-## @app.legal.cookies.page
+## @Legal.Cookies
 
 ### [Signatures]
 ```ts
-export default function CookiesPage() {
-  const { t } = useI18n();
+export default function CookiesPage(): JSX.Element
 ```
 
 ### [Governance]
-- **Encapsulation_Law:** Strictly adheres to file-level opacity rules.
-- **Grammar_Bridge:** Mirrors `@root/hashes/grammar/typescript.hash.md`
+- **I18n_Boundary:** Strictly resolves all cookie-related descriptions through the `useI18n()` hook, ensuring consistency with the global cookie banner.
+- **Motion_Entrance_Law:** Standard module-level entrance animation via `framer-motion`.
 
 ### [Semantic Hash]
-FMCF auto-generated constraint registry for app/legal/cookies/page.tsx
+The UI boundary for the Cookie Policy. It specifies the categories and intents of data storage used by the platform, organized in a high-fidelity visual article.
 
 ### [Linkage]
-- **Dependencies:** 
-  - react
-  - framer-motion
-  - @/lib/effect/I18nProvider
+- **Dependencies:** `@/lib/effect/I18nProvider`, `framer-motion`

--- a/hashes/src/app/legal/layout.hash.md
+++ b/hashes/src/app/legal/layout.hash.md
@@ -1,10 +1,10 @@
 ---
-State_ID: BigInt(0x0fc98cc)
+State_ID: BigInt(0x0fc98e0)
 Git_SHA: LATEST
 Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
 ---
 
-## @App.Legal.Layout
+## @Legal.Layout
 
 ### [Signatures]
 ```ts
@@ -12,11 +12,11 @@ export default function LegalLayout({ children }: { children: React.ReactNode })
 ```
 
 ### [Governance]
-- **Static_Route_Law:** Pure server-side layout. Provides a consistent typographical container (`prose`, max-width constraints) for all descending legal documents.
-- **Seo_Inheritance:** Inherits global metadata from `RootLayout` but scopes UI changes (like minimal headers) out of the main App flow.
+- **Brand_Atmosphere_Sync:** Mandates the use of the `heroMorro` asset and a specific `primary/80` to `accent/70` gradient overlay to maintain visual alignment with the application's core aesthetic.
+- **Structural_Persistence:** Enforces a persistent `Header` and `Footer` placement around the legal content buffer.
 
 ### [Semantic Hash]
-Global wrapper for the `/legal/*` routing segment, ensuring consistent spacing and readability for dense text pages like Privacy and Terms.
+The architectural boundary for all legal and compliance content. It establishes a high-fidelity, thematic background that remains consistent across privacy, terms, and cookie policy pages.
 
 ### [Linkage]
-- **Dependencies:** `react`
+- **Dependencies:** `@/components/layout/Header`, `@/components/layout/Footer`, `next/image`

--- a/hashes/src/app/legal/privacy/page.hash.md
+++ b/hashes/src/app/legal/privacy/page.hash.md
@@ -1,10 +1,10 @@
 ---
-State_ID: BigInt(0x0fc98cc)
+State_ID: BigInt(0x0fc98e1)
 Git_SHA: LATEST
 Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
 ---
 
-## @App.Legal.Privacy
+## @Legal.Privacy
 
 ### [Signatures]
 ```ts
@@ -12,11 +12,11 @@ export default function PrivacyPage(): JSX.Element
 ```
 
 ### [Governance]
-- **Static_Page_Law:** Generates purely static HTML at build time. No client-side hooks or interactive states allowed.
-- **Copy_Integrity:** Strictly implements the PR\\AI official privacy legal copy, anchoring the application to real-world data collection laws.
+- **I18n_Boundary:** Strictly mandates the use of `useI18n()` for every heading and body segment to maintain systemic language consistency.
+- **Motion_Entrance_Law:** Enforces a persistent `opacity: 0, y: 20` to `opacity: 1, y: 0` entrance animation via `framer-motion` for all legal content sections.
 
 ### [Semantic Hash]
-The Privacy Policy document. Defines the contract between the PR\\AI AI Assistant and the user regarding PII, telemetry, and Supabase database storage rules.
+The UI boundary for the Privacy Policy. It presents a structured, multi-section article defining data handling practices, localized through the I18n provider.
 
 ### [Linkage]
-- **Dependencies:** `@/components/layout/Header`, `@/components/layout/Footer`, `@/lib/effect/I18nProvider` (for localized legal text)
+- **Dependencies:** `@/lib/effect/I18nProvider`, `framer-motion`

--- a/hashes/src/app/legal/terms/page.hash.md
+++ b/hashes/src/app/legal/terms/page.hash.md
@@ -1,10 +1,10 @@
 ---
-State_ID: BigInt(0x0fc98cc)
+State_ID: BigInt(0x0fc98e2)
 Git_SHA: LATEST
 Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
 ---
 
-## @App.Legal.Terms
+## @Legal.Terms
 
 ### [Signatures]
 ```ts
@@ -12,11 +12,11 @@ export default function TermsPage(): JSX.Element
 ```
 
 ### [Governance]
-- **Static_Page_Law:** Generates purely static HTML at build time. 
-- **Disclaimer_Law:** Clearly delineates that PR\\AI AI responses are synthetically generated and may require human verification for real-time travel planning in Puerto Rico.
+- **I18n_Boundary:** Mandates `useI18n()` resolution for all compliance-related clauses to ensure legal accuracy across languages.
+- **Motion_Entrance_Law:** Consistent with the `legal` module, it enforces a standard `y: 20` entrance reveal for the main article boundary.
 
 ### [Semantic Hash]
-Terms of Service document. Establishes usage limitations, AI liability disclaimers, and intellectual property constraints for the OpenRouter/Supabase stack.
+The UI boundary for the Terms and Conditions. It serves as the primary agreement document for the community, providing a clean, multi-step layout for user rights and responsibilities.
 
 ### [Linkage]
-- **Dependencies:** `@/components/layout/Header`, `@/components/layout/Footer`, `@/lib/effect/I18nProvider`
+- **Dependencies:** `@/lib/effect/I18nProvider`, `framer-motion`

--- a/hashes/src/app/profile/_components/ProfileClient.hash.md
+++ b/hashes/src/app/profile/_components/ProfileClient.hash.md
@@ -1,25 +1,23 @@
 ---
-State_ID: BigInt(0x0fc98cc)
+State_ID: BigInt(0x0fc98e5)
 Git_SHA: LATEST
 Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
 ---
 
-## @Component.ProfileClient
+## @Profile.Client
 
 ### [Signatures]
 ```ts
-export function ProfileClient(): JSX.Element
-function getSupabaseClient(): SupabaseClient<Database>
+export default function ProfileClient({ profile, email, chatsCount }): JSX.Element
 ```
 
 ### [Governance]
-- **Client_Law:** Pure `'use client'` interactive component.
-- **State_Silo:** Manages local form state (`isEditing`, `isSaving`, `displayName`, `bio`, `language`).
-- **Mutation_Law:** Utilizes `getSupabaseClient()` to directly mutate `profiles` table in Supabase. Bypasses Redux in favor of React Context (`useAuth`).
-- **I18n_Law:** Directly mutates global locale via `setLocale` and persists language choice to database.
+- **Auth_Gate_Protected:** Mandates wrapping the entire profile view in a `ProtectedRoute` to prevent unauthorized metadata leakage.
+- **Data_Sovereignty_Modal:** Enforces a multi-step confirmation flow for account deletion, including a handle-match verification and a high-fidelity warning modal.
+- **I18n_Boundary:** Strictly resolves all profile labels (bio, data controls, danger zone) through the `useI18n` hook.
 
 ### [Semantic Hash]
-Interactive dashboard wrapper for user identity management. Handles the edit/save flow, optimistic UI updates, and Supabase integration.
+The private UI boundary for user account management. It facilitates profile metadata viewing, data archival/deletion, and the final account closure process, ensuring a secure and user-centric data control interface.
 
 ### [Linkage]
-- **Dependencies:** `@root/src/components/layout/Header.tsx`, `@root/contexts/AuthContext.tsx`, `@root/components/ui/ToastProvider.tsx`, `@supabase/ssr`
+- **Dependencies:** `@/components/auth/ProtectedRoute`, `@/lib/effect/I18nProvider`, `framer-motion`, `lucide-react`

--- a/hashes/src/app/releases/ReleasesClient.hash.md
+++ b/hashes/src/app/releases/ReleasesClient.hash.md
@@ -1,60 +1,23 @@
 ---
-State_ID: BigInt(0x2)
+State_ID: BigInt(0x0fc98ea)
 Git_SHA: LATEST
-Grammar_Lock: "@root/hashes/grammar/next.hash.md"
+Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
 ---
 
-## @UI.Page.Releases
+## @Releases.Client
 
 ### [Signatures]
-```tsx
+```ts
 export function ReleasesPage({ releases }: { releases: Release[] }): JSX.Element
-
-function ExpandableContent({ content }: { content: string }): JSX.Element
-function truncateAtWordBoundary(content: string, maxChars: number): string
-
-const MAX_CHARS_PREVIEW = 300
 ```
 
-### [Components]
-| Component | Description |
-|-----------|-------------|
-| `ReleasesPage` | Main page wrapper with Context provider |
-| `Background` | Glowing background effects (fixed position) |
-| `Breadcrumb` | Logo and follow button row |
-| `HeroHeader` | Hero section with title, subtitle, social actions |
-| `SocialActions` | RSS and API feed buttons with links to endpoints |
-| `Timeline` | Container for release cards |
-| `TimelineCard` | Individual release with motion animation |
-| `ExpandableContent` | Expandable/collapsible content with truncation |
-| `VersionInfo` | Version number and product label |
-| `DateColumn` | Sticky date display |
-| `LogoColumn` | AI avatar column |
-| `Content` | Markdown renderer using markdown-it |
-
-### [Context]
-- **ReleasesContext:** Provides `releases` array to all children
-
-### [Features]
-- **ExpandableContent:** When content exceeds 300 characters:
-  - Shows truncated preview with gradient fade effect
-  - "Ver más" button to expand full content
-  - "Ver menos" button to collapse with smooth scroll-to-top
-  - Uses `scrollIntoView` for smooth scrolling on collapse
-- **SocialActions:** RSS and API feed buttons linking to:
-  - `/releases/feed.xml` - RSS feed endpoint
-  - `/api/releases` - JSON API endpoint
-
 ### [Governance]
-- **Context_Law:** Uses React Context for state sharing
-- **I18n_Law:** All text via `useI18n()`
-- **Animation_Law:** Uses Framer Motion for staggered animations
-- **Truncation_Law:** HTML tags preserved during truncation via `truncateAtWordBoundary`
+- **Timeline_Aesthetic_Lock:** Enforces a persistent, high-fidelity grid layout (`#090909` background, `white/[0.03]` borders) for the version timeline to match the platform's dark-mode identity.
+- **I18n_Boundary:** Strictly resolves all interactive labels (show more/less, breadcrumbs) through the `useI18n` hook.
+- **Motion_Timeline_Reveal:** Mandates `whileInView` opacity and y-axis transitions via `framer-motion` for each `TimelineCard`.
 
 ### [Semantic Hash]
-Release notes page with timeline layout, expandable content, animated cards, and markdown rendering.
+The primary UI boundary for the community's progress history. It provides an interactive, accessible timeline of platform updates, optimized for readability and visual engagement.
 
 ### [Linkage]
-- **Upstream:** `Release` type from `@/lib/effect/services/Changelog`
-- **Downstream:** Layout components (Header, Footer)
-- **Feed Endpoints:** Links to `/releases/feed.xml` and `/api/releases`
+- **Dependencies:** `@/lib/effect/I18nProvider`, `framer-motion`, `lucide-react`

--- a/hashes/src/app/releases/feed.xml/route.hash.md
+++ b/hashes/src/app/releases/feed.xml/route.hash.md
@@ -1,0 +1,22 @@
+---
+State_ID: BigInt(0x0fc98eb)
+Git_SHA: LATEST
+Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
+---
+
+## @Route.Feed.RSS
+
+### [Signatures]
+```ts
+export async function GET(): Promise<NextResponse>
+```
+
+### [Governance]
+- **RSS_Schema_Compliance:** Strictly enforces the generation of a valid RSS 2.0 XML schema, including CDATA encapsulation for content and proper Date formatting.
+- **Changelog_Service_Bridge:** Reuses the centralized `Changelog` service to ensure the feed remains perfectly synchronized with the UI.
+
+### [Semantic Hash]
+The automated distribution boundary for platform updates. It serves a machine-readable feed of all release notes, enabling external aggregators and subscription services to track PR\\AI's evolution.
+
+### [Linkage]
+- **Dependencies:** `@/lib/effect/services/Changelog`

--- a/hashes/src/app/releases/page.hash.md
+++ b/hashes/src/app/releases/page.hash.md
@@ -1,32 +1,21 @@
 ---
-State_ID: BigInt(0x0)
+State_ID: BigInt(0x0fc98e9)
 Git_SHA: LATEST
-Grammar_Lock: "@root/hashes/grammar/next.hash.md"
+Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
 ---
 
-## @Route.Releases
+## @Releases.Page
 
 ### [Signatures]
-```tsx
-export default function ReleasesPageRoute(): JSX.Element
-export const metadata: Metadata
-```
-
-### [Metadata]
 ```ts
-{
-  title: 'Release Notes | PR\\AI',
-  description: 'The latest updates, features, and fixes for the PR\\AI platform.'
-}
+export default function Page(): Promise<JSX.Element>
 ```
 
 ### [Governance]
-- **Static_Law:** Page is statically prerendered
-- **Server_Law:** Data fetched server-side via `getChangelogReleasesSync()`
+- **Changelog_Service_Bridge:** Mandates the retrieval of release data through `getChangelogReleasesSync` to maintain a single source of truth for version history.
 
 ### [Semantic Hash]
-Server component that fetches changelog data and renders the releases page.
+The main entry point for the platform's public changelog. It fetches structured release data and passes it to the `ReleasesClient` for interactive rendering.
 
 ### [Linkage]
-- **Upstream:** `getChangelogReleasesSync` from `@/lib/effect/services/Changelog`
-- **Downstream:** `ReleasesPage` from `./ReleasesClient`
+- **Dependencies:** `./ReleasesClient`, `@/lib/effect/services/Changelog`


### PR DESCRIPTION
This PR synchronizes the `src/app` directory with the FMCF Hash Registry, establishing a 1:1 mirroring between implementation and registry planes.

### Changes
- Generated 1:1 mirror hashes for all `src/app` modules.
- Updated `hashes/local.map.json` with 25+ new contract nodes.
- Updated `hashes/atlas.graph.json` with cross-module dependency edges.
- Enforced neutral, professional language in all architectural contracts.

Closes #57