### PR TITLE
chore: sync FMCF hash registry with src changes (#71)

### DIFF
--- a/hashes/src/app/api/user/personalization/route.hash.md
+++ b/hashes/src/app/api/user/personalization/route.hash.md
@@ -1,0 +1,24 @@
+---
+State_ID: BigInt(0x0)
+Git_SHA: LATEST
+Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
+---
+
+## @Route.User.Personalization
+
+### [Signatures]
+```ts
+export async function GET(request: NextRequest): NextResponse
+export async function POST(request: NextRequest): NextResponse
+```
+
+### [Governance]
+- **Auth_Law:** Requires authentication via Supabase session.
+- **Validation_Law:** POST validates body against PersonalizationBodySchema with Effect Schema.
+
+### [Semantic Hash]
+API endpoints for user personalization. GET fetches preferences, POST saves them.
+
+### [Linkage]
+- **Upstream:** `@root/src/app/api/user/personalization/services/personalization.ts`
+- **Downstream:** `@root/src/hooks/usePersonalization.ts`

--- a/hashes/src/app/api/user/personalization/services/personalization.hash.md
+++ b/hashes/src/app/api/user/personalization/services/personalization.hash.md
@@ -1,0 +1,24 @@
+---
+State_ID: BigInt(0x0)
+Git_SHA: LATEST
+Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
+---
+
+## @Service.Api.User.Personalization
+
+### [Signatures]
+```ts
+export const getPersonalization: (userId: string) => Effect.Effect<Personalization, ChatDbError>
+export const savePersonalization: (userId: string, prefs: unknown) => Effect.Effect<Personalization, ChatDbError>
+```
+
+### [Governance]
+- **Database_Law:** Reads/writes to profiles.preferences JSON column.
+- **Schema_Law:** Uses Schema.decodeUnknownEither for validation.
+
+### [Semantic Hash]
+Effect service for personalization database operations.
+
+### [Linkage]
+- **Upstream:** PersonalizationSchema, Supabase client
+- **Downstream:** `@root/src/app/api/user/personalization/route.ts`

--- a/hashes/src/app/api/user/usage/route.hash.md
+++ b/hashes/src/app/api/user/usage/route.hash.md
@@ -9,11 +9,13 @@ Grammar_Lock: "@root/hashes/grammar/next.hash.md"
 ### [Signatures]
 ```ts
 export async function GET(request: NextRequest): NextResponse<UserUsage>
+export async function POST(request: NextRequest): NextResponse<UserUsage>
 ```
 
 ### [Governance]
 - **Auth_Law:** Requires authentication via Supabase session.
 - **Effect_Law:** Uses Effect framework pattern with `exitResponse`.
+- **Usage_Law:** GET fetches usage stats, POST increments usage count.
 
 ### [Semantic Hash]
 GET endpoint returning user's current usage statistics including next_reset_date calculation.

--- a/hashes/src/components/chat/ChatContainer.hash.md
+++ b/hashes/src/components/chat/ChatContainer.hash.md
@@ -16,7 +16,6 @@ export const Chat: {
   Messages: ({ children, scrollAreaRef, innerRef, onScroll, className }) => JSX.Element
   Input: ({ value, onChange, onSend, isLoading, showScrollButton, onScrollToBottom, suggestions, textareaRef, isRecording, onMicClick, stopResponse, t, isAtLimit, isAuthenticated, usage, isUsageVisible, onToggleUsage }) => JSX.Element
 }
-```
 
 ### [Governance]
 - **Performance_Law:** `MemoizedMessageBubble` used for the message list to prevent heavy stream re-renders.
@@ -24,6 +23,7 @@ export const Chat: {
 - **Auto_Chat_Law:** Creates new chat automatically when visiting `/chat` with no `currentChatId`.
 - **URL_Sync_Law:** Updates URL to `/chat/:id` when returning with existing chat via `usePathname`.
 - **Usage_Law:** Displays inline usage bar with progress, remaining messages count, and limit warnings. Usage pill can be toggled visible/hidden.
+- **Personalization_Law:** Uses usePersonalization hook to pass preferences to chat messages.
 
 ### [Implementation Notes]
 - **Component Code Splitting:** Heavy components like `AdaptiveCard` are lazily loaded via Next.js `dynamic()`.

--- a/hashes/src/components/chat/PersonalizationNestedView.hash.md
+++ b/hashes/src/components/chat/PersonalizationNestedView.hash.md
@@ -1,0 +1,29 @@
+---
+State_ID: BigInt(0x0)
+Git_SHA: LATEST
+Grammar_Lock: "@root/hashes/grammar/next.hash.md"
+---
+
+## @UI.Chat.PersonalizationNestedView
+
+### [Signatures]
+```tsx
+interface PersonalizationNestedViewProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+export function PersonalizationNestedView(props: PersonalizationNestedViewProps): JSX.Element | null
+```
+
+### [Implementation Notes]
+- Nested view within chat for quick personalization access
+- Displays current personalization settings
+- Allows editing base style and characteristics
+
+### [Semantic Hash]
+Nested view component for personalization within chat interface.
+
+### [Linkage]
+- **Upstream:** `@root/src/hooks/usePersonalization.ts`
+- **Downstream:** `@root/src/components/chat/ChatContainer.tsx`

--- a/hashes/src/components/chat/SidebarProfile.hash.md
+++ b/hashes/src/components/chat/SidebarProfile.hash.md
@@ -16,6 +16,7 @@ Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
 - **I18n_Law**: All text strings resolved via `useI18n()`.
 - **Animation_Law**: Uses Framer Motion for popover enter/exit transitions (`menuVariants`, `tabVariants`).
 - **Usage_Law**: Fetches usage on mount, displays TierBadge next to username, includes link to `/usage` page.
+- **Personalization_Law**: Includes link to `/personalization` in help tab.
 
 ### [Linkage]
 - **Upstream**: `contexts/AuthContext`, `hooks/useUsage`, `components/usage/TierBadge`, framer-motion, lucide-react.

--- a/hashes/src/components/ui/PersonalizationModal.hash.md
+++ b/hashes/src/components/ui/PersonalizationModal.hash.md
@@ -1,0 +1,32 @@
+---
+State_ID: BigInt(0x0)
+Git_SHA: LATEST
+Grammar_Lock: "@root/hashes/grammar/next.hash.md"
+---
+
+## @UI.Personalization.Modal
+
+### [Signatures]
+```tsx
+interface PersonalizationModalProps {
+  isOpen?: boolean
+  onClose?: () => void
+}
+
+export function PersonalizationModal(props: PersonalizationModalProps): JSX.Element | null
+```
+
+### [Implementation Notes]
+- Sidebar navigation with tabs: General, Notifications, Personalization, Apps, Data, Security, Account
+- Style selection: Default, Professional, Friendly, Candid, Quirky, Efficient, Cynical
+- Characteristic sliders: Warmth, Enthusiasm, Headers & Lists, Emoji
+- Custom instructions textarea
+- Nickname input
+- About me section
+
+### [Semantic Hash]
+Modal UI for user personalization settings with style/tone configuration.
+
+### [Linkage]
+- **Upstream:** `@root/src/hooks/usePersonalization.ts`, `@root/src/lib/effect/i18n/index.ts`
+- **Downstream:** `@root/src/app/personalization/page.tsx`

--- a/hashes/src/hooks/usePersonalization.hash.md
+++ b/hashes/src/hooks/usePersonalization.hash.md
@@ -1,0 +1,30 @@
+---
+State_ID: BigInt(0x0)
+Git_SHA: LATEST
+Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
+---
+
+## @Hook.UsePersonalization
+
+### [Signatures]
+```ts
+export function usePersonalization(): {
+  readonly personalization: Personalization
+  readonly loading: boolean
+  readonly error: string | null
+  readonly fetchPersonalization: () => Promise<void>
+  readonly savePersonalization: (newPrefs: Personalization) => Promise<Personalization | null>
+  readonly setPersonalization: (prefs: Personalization) => void
+}
+```
+
+### [Governance]
+- **Fetch_Law:** Fetches personalization on mount if authenticated.
+- **Save_Law:** Posts to `/api/user/personalization` with `{ preferences: newPrefs }`.
+
+### [Semantic Hash]
+React hook for managing user personalization state with API integration.
+
+### [Linkage]
+- **Upstream:** `@root/src/app/api/user/personalization/route.ts`
+- **Downstream:** `@root/src/components/chat/ChatContainer.tsx`, `@root/src/components/ui/PersonalizationModal.tsx`

--- a/hashes/src/lib/effect/ChatProvider.hash.md
+++ b/hashes/src/lib/effect/ChatProvider.hash.md
@@ -13,7 +13,9 @@ export const useChatActions: () => ChatContextType
 export const useChatStore: () => ChatContextType  // Deprecated alias
 
 interface ChatContextType {
-  sendMessage: (content: string) => Promise<void>
+  sendMessage: (content: string, personalization?: Personalization) => Promise<void>
+  regenerateMessage: (personalization?: Personalization) => Promise<void>
+  editMessage: (index: number, content: string, personalization?: Personalization) => Promise<void>
   clearHistory: () => void
   startVoice: (onResult: (text: string, isFinal: boolean) => void) => void
   stopVoice: () => void
@@ -23,6 +25,7 @@ interface ChatContextType {
 ### [Governance]
 - **Bridge_Law:** Correct pattern — React bridge calls `runtime.runPromise(effect)` wrapped in `.catch()` boundary.
 - **Render_Law:** Callbacks (`sendMessage`, etc.) memoized with `useCallback` to prevent re-renders.
+- **Personalization_Law:** sendMessage, regenerateMessage, and editMessage accept optional personalization parameter.
 
 ### [Implementation Notes]
 - **Error Boundaries:** The React bridge ensures `runtime.runPromise` is wrapped in `.catch()` to handle Promise rejections safely.

--- a/hashes/src/lib/effect/chat.hash.md
+++ b/hashes/src/lib/effect/chat.hash.md
@@ -9,8 +9,14 @@ Grammar_Lock: "@root/hashes/grammar/effect.hash.md"
 ### [Signatures]
 ```ts
 export const initChat: Effect<void, never, ConfigService | Redux>
-export const sendChatMessage: (content: string) => Effect<void, never, OpenRouter | Redux | ConfigService | ChatApi>
-export const regenerateResponse: Effect.Effect<void, never, OpenRouter | Redux | ConfigService>
+export const sendChatMessage: (content: string, personalization?: Personalization) => Effect<void, never, OpenRouter | Redux | ConfigService | ChatApi>
+export const regenerateResponse: (personalization?: Personalization) => Effect.Effect<void, never, OpenRouter | Redux | ConfigService>
+```
+
+**Internal:**
+```ts
+const generateResponse: (sessionId?: string, personalization?: Personalization) => Effect<void, OpenRouterError | void, OpenRouter | Redux>
+// Accepts optional sessionId for OpenRouter session tracking and personalization for system prompt injection
 ```
 
 **Internal:**

--- a/hashes/src/lib/effect/i18n/index.hash.md
+++ b/hashes/src/lib/effect/i18n/index.hash.md
@@ -23,7 +23,7 @@ export function I18nProvider(props: { children: React.ReactNode; initialLocale?:
 - **Locale_Sync:** Automatically synchronizes with cookie storage `NEXT_LOCALE`.
 
 ### [Semantic Hash]
-Global localization context managing translations for Auth, Profile, Nav, Chat, Legal, and Usage domains.
+Global localization context managing translations for Auth, Profile, Nav, Chat, Legal, Usage, and Personalization domains.
 
 ### [Linkage]
 - **Dependencies:** `react`, `js-cookie`

--- a/hashes/src/lib/effect/schemas/PersonalizationSchema.hash.md
+++ b/hashes/src/lib/effect/schemas/PersonalizationSchema.hash.md
@@ -1,0 +1,37 @@
+---
+State_ID: BigInt(0x0)
+Git_SHA: LATEST
+Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
+---
+
+## @Schema.Effect.Personalization
+
+### [Signatures]
+```ts
+export const BaseStyleSchema = S.Literal("default", "professional", "friendly", "candid", "quirky", "efficient", "cynical")
+export const CharacteristicLevelSchema = S.Literal("more", "default", "less")
+
+export const PersonalizationSchema = S.Struct({
+  baseStyle: S.optionalWith(BaseStyleSchema, { default: () => "default" }),
+  warm: S.optionalWith(CharacteristicLevelSchema, { default: () => "default" }),
+  enthusiastic: S.optionalWith(CharacteristicLevelSchema, { default: () => "default" }),
+  headersAndLists: S.optionalWith(CharacteristicLevelSchema, { default: () => "default" }),
+  emoji: S.optionalWith(CharacteristicLevelSchema, { default: () => "default" }),
+  customInstructions: S.optionalWith(S.String, { default: () => "" }),
+  nickname: S.optionalWith(S.String, { default: () => "" }),
+  aboutMe: S.optionalWith(S.String, { default: () => "" }),
+})
+
+export type Personalization = S.Schema.Type<typeof PersonalizationSchema>
+export const DEFAULT_PERSONALIZATION: Personalization = { ... }
+```
+
+### [Governance]
+- **Schema_Law:** All fields have defaults via `optionalWith`.
+
+### [Semantic Hash]
+Effect Schema for user personalization settings including base style, characteristics, custom instructions, and nickname.
+
+### [Linkage]
+- **Upstream:** User preferences from database
+- **Downstream:** `@root/src/lib/effect/services/prompts/personalization.ts`, `@root/src/lib/effect/services/Personalization.ts`, `@root/src/hooks/usePersonalization.ts`

--- a/hashes/src/lib/effect/services/OpenRouter.hash.md
+++ b/hashes/src/lib/effect/services/OpenRouter.hash.md
@@ -19,7 +19,7 @@ export class OpenRouter extends Effect.Service<OpenRouter>()("OpenRouter", {
 **Interface:**
 ```ts
 interface OpenRouterShape {
-  readonly chat: (messages: readonly ChatMessage[], searchOptions?: PuertoRicoSearchOptions, sessionId?: string) => Stream.Stream<ChatResponse, OpenRouterError, never>
+  readonly chat: (messages: readonly ChatMessage[], searchOptions?: PuertoRicoSearchOptions, sessionId?: string, personalization?: Personalization) => Stream.Stream<ChatResponse, OpenRouterError, never>
 }
 ```
 

--- a/hashes/src/lib/effect/services/Personalization.hash.md
+++ b/hashes/src/lib/effect/services/Personalization.hash.md
@@ -1,0 +1,29 @@
+---
+State_ID: BigInt(0x0)
+Git_SHA: LATEST
+Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
+---
+
+## @Service.Effect.Personalization
+
+### [Signatures]
+```ts
+export class PersonalizationService extends Effect.Service<PersonalizationService>()("Personalization", {
+  effect: Effect.gen(function* () {
+    const loadPersonalization: (userId: string) => Effect.Effect<Personalization, ChatDbError>
+    const savePersonalization: (userId: string, prefs: unknown) => Effect.Effect<Personalization, ChatDbError>
+    const getPersonalization: () => Effect.Effect<Personalization>
+  })
+})
+```
+
+### [Governance]
+- **Effect_Law:** Uses Effect framework with typed error channel.
+- **Schema_Law:** Validates incoming preferences via PersonalizationSchema before save.
+
+### [Semantic Hash]
+Effect service for loading and saving user personalization to Supabase profiles.preferences JSON column.
+
+### [Linkage]
+- **Upstream:** PersonalizationSchema, Supabase client
+- **Downstream:** `@root/src/lib/effect/services/PromptBuilder.ts`, `@root/src/lib/effect/chat.ts`

--- a/hashes/src/lib/effect/services/PromptBuilder.hash.md
+++ b/hashes/src/lib/effect/services/PromptBuilder.hash.md
@@ -19,7 +19,7 @@ export class PromptBuilderService extends Effect.Service<PromptBuilderService>()
 **Interface:**
 ```ts
 interface PromptBuilderShape {
-  readonly compose: (extraCapabilities?: string) => string
+  readonly compose: (extraCapabilities?: string, personalization?: Personalization) => string
 }
 ```
 
@@ -27,9 +27,10 @@ interface PromptBuilderShape {
 - **Layer_Law:** Exposed via `PromptBuilderService.Default`. No external dependencies.
 - **Export_Law:** Single Effect.Service class export. Consumed via tag yield*.
 - **Transformation_Law:** Pure string composition — no I/O, no side effects.
+- **Personalization_Law:** Injects personalization section into system prompt when provided.
 
 ### [Semantic Hash]
-Builds the LLM system prompt string by composing domain template sections. Includes role, safety, rules, guardrails, media accuracy, and output format templates.
+Builds the LLM system prompt string by composing domain template sections. Includes role, safety, rules, guardrails, media accuracy, output format, and personalization templates.
 
 ### [Linkage]
 - **Upstream:** None

--- a/hashes/src/lib/effect/services/prompts/index.hash.md
+++ b/hashes/src/lib/effect/services/prompts/index.hash.md
@@ -8,11 +8,24 @@ Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
 
 ### [Signatures]
 ```ts
-// Prompt generation functions
+export {
+  role,
+  guardrails,
+  rules,
+  family_safety,
+  search_config,
+  thought_process,
+  accuracy_and_media,
+  action_handling,
+  output_format,
+  titleSystemPrompt,
+  buildPersonalizationPrompt
+}
 ```
 
 ### [Semantic Hash]
-Prompt building blocks for AI chat.
+Prompt building blocks for AI chat including role, safety, rules, media accuracy, output format, and personalization templates.
 
 ### [Linkage]
 - **Dependencies:** Chat service, Config service
+- **Downstream:** `@root/src/lib/effect/services/PromptBuilder.ts`

--- a/hashes/src/lib/effect/services/prompts/personalization.hash.md
+++ b/hashes/src/lib/effect/services/prompts/personalization.hash.md
@@ -1,0 +1,26 @@
+---
+State_ID: BigInt(0x0)
+Git_SHA: LATEST
+Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
+---
+
+## @Logic.Effect.Prompts.Personalization
+
+### [Signatures]
+```ts
+export const buildPersonalizationPrompt: (prefs: Personalization) => string
+```
+
+### [Implementation Notes]
+- Converts personalization settings to LLM instruction text
+- Maps baseStyle to tone persona (professional, friendly, candid, quirky, efficient, cynical)
+- Converts characteristic levels (more/default/less) to modifier instructions
+- Includes custom instructions as explicit behavioral rules
+- Includes nickname for user address
+
+### [Semantic Hash]
+Generates personalization section for system prompt based on user preferences.
+
+### [Linkage]
+- **Upstream:** PersonalizationSchema
+- **Downstream:** `@root/src/lib/effect/services/PromptBuilder.ts`


### PR DESCRIPTION
## Summary

Synchronize the FMCF Hash Registry with the latest src/ changes. Update existing hash files and create new ones for personalization and usage features.

## Changes

- Add 8 new hash files for personalization feature
- Update 9 existing hash files with new signatures and governance laws
- All TypeScript and lint checks pass

Closes #71