### PR TITLE
perf: cache releases at build time (#76)

### DIFF
--- a/src/app/api/releases/route.ts
+++ b/src/app/api/releases/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from 'next/server'
 import { getChangelogReleasesSync } from '@/lib/effect/services/Changelog'
 import { HttpStatus } from '@/app/api/_lib/constants/status-codes'
 
+export const dynamic = 'force-static'
+
 /** @Route.Api.Releases */
 /** @Route.Api.Releases.GET */
 export async function GET(): Promise<NextResponse> {

--- a/src/app/releases/feed.xml/route.ts
+++ b/src/app/releases/feed.xml/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server'
 import { getChangelogReleasesSync } from '@/lib/effect/services/Changelog'
 
+export const dynamic = 'force-static'
+
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || ''
 const SITE_TITLE = 'PR\\AI Release Notes'
 const SITE_DESCRIPTION = 'The latest updates, features, and fixes for the PR\\AI platform.'

--- a/src/app/releases/page.tsx
+++ b/src/app/releases/page.tsx
@@ -2,6 +2,8 @@ import { getChangelogReleasesSync } from '@/lib/effect/services/Changelog'
 import { ReleasesPage } from './ReleasesClient'
 import type { Metadata } from 'next'
 
+export const dynamic = 'force-static'
+export const revalidate = false
 
 export const metadata: Metadata = {
   title: 'Release Notes | PR\\AI',


### PR DESCRIPTION
## Summary

Implement force-static caching for all releases endpoints to optimize for high traffic.

## Changes

- Add `dynamic = 'force-static'` to releases page, API, and RSS feed
- Serves pre-rendered static content from CDN
- Zero disk I/O on requests

## Result

- Build time: CHANGELOG.md parsed once
- Runtime: Zero server compute
- Scalable for high traffic

Closes #76