### PR TITLE
perf: refactor pricing page to server-side rendering (#78)

### DIFF
--- a/public/content/pricing/en.md
+++ b/public/content/pricing/en.md
@@ -1,0 +1,40 @@
+**Our app uses free OpenRouter models**
+
+Our Puerto Rico Tourism Assistant uses OpenRouter’s Free Models Router (`openrouter/free`).
+
+### How it works
+
+Every time you send a message about Puerto Rico — whether you're asking for the best beaches, food recommendations, hiking trails, or help planning your trip — our app automatically routes your request through openrouter/free.
+
+This smart router:
+- Checks which free AI models are available at that moment.
+- Selects the ones that can best handle your request (text, images, or other features).
+- Picks one at random from the suitable free models.
+- Uses that model to generate your response.
+
+**Key details:**
+- It is completely free ($0 per million input and output tokens).
+- Supports up to 200,000 tokens of context, which is ideal for long and detailed conversations.
+- Released on February 1, 2026.
+
+### Current limits
+
+These limits are set by OpenRouter so they can offer free models to everyone:
+
+- Maximum of 20 messages per minute.
+- Approximately 50 messages per day.
+
+We apologize for any inconvenience this may cause when the limits are reached. We want everyone to be able to use the assistant at no cost, which is why we have these limits in place to keep the service available and stable for all users.
+
+### Coming Soon: Pro Plan
+
+We are working on launching a Pro Plan very soon.
+
+With the Pro Plan you will enjoy:
+- Access to more powerful premium AI models for faster and higher-quality responses.
+- Much higher or unlimited daily limits.
+- Real-time web search, so the AI can bring you up-to-date information such as the current weather in San Juan, today’s events, flight deals, restaurant hours, and the latest tourism updates across Puerto Rico.
+
+The Pro Plan will still be powered by OpenRouter, but using more advanced models with online search capabilities.
+
+We will keep the free version available so everyone can continue exploring Puerto Rico with our AI assistant.

--- a/public/content/pricing/es.md
+++ b/public/content/pricing/es.md
@@ -1,0 +1,40 @@
+**Nuestra app usa modelos gratuitos de OpenRouter**
+
+Nuestro Asistente de Turismo de Puerto Rico utiliza el Router de Modelos Gratuitos de OpenRouter (`openrouter/free`).
+
+### Cómo funciona
+
+Cada vez que envías un mensaje sobre Puerto Rico — ya sea preguntando por las mejores playas, recomendaciones de comida, rutas de senderismo o ayuda para planificar tu viaje — nuestra aplicación dirige automáticamente tu solicitud a través de openrouter/free.
+
+Este router inteligente:
+- Revisa qué modelos de IA gratuitos están disponibles en ese momento.
+- Selecciona los que mejor pueden responder a tu pregunta (texto, imágenes u otras funciones).
+- Elige uno al azar entre los modelos adecuados.
+- Usa ese modelo para generar tu respuesta.
+
+**Detalles importantes:**
+- Es completamente gratis ($0 por millón de tokens de entrada y salida).
+- Permite hasta 200.000 tokens de contexto, ideal para conversaciones largas y detalladas.
+- Fue lanzado el 1 de febrero de 2026.
+
+### Límites actuales
+
+Estos límites los establece OpenRouter para poder ofrecer los modelos de forma gratuita a todos los usuarios:
+
+- Máximo de 20 mensajes por minuto.
+- Aproximadamente 50 mensajes por día.
+
+Lamentamos las molestias que esto pueda causar cuando se alcanzan los límites. Queremos que todos puedan usar el asistente sin costo, por eso aplicamos estos límites para mantener el servicio disponible y estable.
+
+### Próximamente: Plan Pro
+
+Estamos trabajando en lanzar un Plan Pro muy pronto.
+
+Con el Plan Pro podrás disfrutar de:
+- Modelos de IA premium más potentes, con respuestas más rápidas y de mejor calidad.
+- Límites diarios mucho más altos o ilimitados.
+- Búsqueda web en tiempo real, para que la IA pueda traerte información actualizada como el clima en San Juan, eventos del día, ofertas de vuelos, horarios de restaurantes y las últimas novedades turísticas de Puerto Rico.
+
+El Plan Pro seguirá funcionando con OpenRouter, pero usando modelos más avanzados con capacidades de búsqueda en internet.
+
+Mantendremos la versión gratuita disponible para que todas las personas puedan seguir explorando Puerto Rico con nuestro asistente de IA.

--- a/src/app/pricing/PricingContent.tsx
+++ b/src/app/pricing/PricingContent.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+import { useI18n } from '@/lib/effect/I18nProvider'
+import { cn } from '@/lib/utils'
+import { Header } from '@/components/layout/Header'
+import { Footer } from '@/components/layout/Footer'
+import { PraiLogo } from '@/components/brand/PraiLogo'
+
+interface PricingContentProps {
+  esContent: string
+  enContent: string
+}
+
+/** @UI.Pricing.Background */
+function Background() {
+  return (
+    <div className="fixed inset-0 pointer-events-none z-0">
+      <div className="absolute top-[-10%] left-[-10%] w-[40%] h-[40%] rounded-full bg-primary/10 blur-[120px]" />
+      <div className="absolute bottom-[-10%] right-[-10%] w-[40%] h-[40%] rounded-full bg-accent/10 blur-[120px]" />
+    </div>
+  )
+}
+
+/** @UI.Pricing.Main */
+export function PricingContent({ esContent, enContent }: PricingContentProps) {
+  const { locale, t } = useI18n()
+  const content = locale === 'en' ? enContent : esContent
+
+  return (
+    <main className="relative min-h-screen bg-[#090909] overflow-x-hidden selection:bg-white/10 selection:text-white">
+      <Background />
+
+      <div className="relative z-10 flex flex-col min-h-screen font-body">
+        <Header transparent={true} />
+
+        <section className="flex-1 px-6 md:px-10 lg:px-16 max-w-4xl mx-auto pt-32 pb-40 w-full animate-in fade-in duration-700">
+          <div className="w-full">
+            {/* Breadcrumb */}
+            <div className="flex items-center gap-3 mb-12">
+              <PraiLogo white size={18} animate />
+              <span className="text-white/10 font-thin">|</span>
+              <span className="text-[11px] font-bold text-white/30 uppercase tracking-[0.3em]">
+                {t('pricing.title')}
+              </span>
+            </div>
+
+            {/* Markdown Content */}
+            <div
+              className={cn(
+                'prose prose-invert max-w-none',
+                'prose-headings:text-white prose-headings:font-black prose-headings:tracking-tight',
+                'prose-p:text-white/60 prose-p:leading-relaxed prose-p:text-lg',
+                'prose-strong:text-white prose-strong:font-black',
+                'prose-ul:text-white/60 prose-li:my-2',
+                'prose-code:text-primary prose-code:bg-primary/10 prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded-md prose-code:before:content-none prose-code:after:content-none',
+                'prose-hr:border-white/5 prose-hr:my-10',
+              )}
+              dangerouslySetInnerHTML={{ __html: content }}
+            />
+          </div>
+        </section>
+
+        <Footer className="mt-auto bg-transparent border-t border-white/[0.03] pt-10 pb-10" />
+      </div>
+    </main>
+  )
+}

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,0 +1,32 @@
+import type { Metadata } from 'next'
+import MarkdownIt from 'markdown-it'
+import fs from 'node:fs'
+import path from 'node:path'
+import { PricingContent } from './PricingContent'
+
+export const dynamic = 'force-static'
+
+const md = new MarkdownIt({
+  html: true,
+  linkify: true,
+  typographer: true,
+})
+
+export const metadata: Metadata = {
+  title: 'Precios | PR\\AI',
+  description: 'Compara nuestros planes y descubre el poder de PR\\AI.',
+}
+
+function getPricingContent(locale: string): string {
+  const filePath = path.join(process.cwd(), 'public', 'content', 'pricing', `${locale}.md`)
+  const content = fs.readFileSync(filePath, 'utf8')
+  return md.render(content)
+}
+
+/** @Route.Pricing */
+export default function PricingRoute() {
+  const esContent = getPricingContent('es')
+  const enContent = getPricingContent('en')
+
+  return <PricingContent esContent={esContent} enContent={enContent} />
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -63,6 +63,7 @@ export function Header({
   const navLinks = [
     { label: t('nav.about'), key: 'about', href: '/about' },
     { label: t('nav.releases'), key: 'releases', href: '/releases' },
+    { label: t('pricing.title'), key: 'pricing', href: '/pricing' },
   ]
 
   const toggleMenu = () => setIsMenuOpen(!isMenuOpen)
@@ -205,10 +206,7 @@ export function Header({
                       <NotificationBell />
 
                       {/* Avatar Dropdown */}
-                      <div
-                        className="relative"
-                        ref={dropdownRef}
-                      >
+                      <div className="relative" ref={dropdownRef}>
                         <button
                           onClick={() => setIsDropdownOpen(!isDropdownOpen)}
                           className={cn(
@@ -249,8 +247,8 @@ export function Header({
                               exit={{ opacity: 0, y: -10, scale: 0.95 }}
                               transition={{ duration: 0.15 }}
                               className={cn(
-                                "fixed md:absolute left-4 right-4 md:left-auto md:right-0 top-[76px] md:top-full md:mt-2 w-auto md:w-56",
-                                "bg-[#1a1a1a] border border-white/10 rounded-2xl shadow-2xl overflow-hidden z-[110] origin-top md:origin-top-right transform-gpu"
+                                'fixed md:absolute left-4 right-4 md:left-auto md:right-0 top-[76px] md:top-full md:mt-2 w-auto md:w-56',
+                                'bg-[#1a1a1a] border border-white/10 rounded-2xl shadow-2xl overflow-hidden z-[110] origin-top md:origin-top-right transform-gpu',
                               )}
                             >
                               <div className="px-4 py-3 border-b border-white/10">
@@ -258,13 +256,17 @@ export function Header({
                                   <p className="text-sm font-bold text-white truncate">
                                     {userName}
                                   </p>
-                                  <span className={cn(
-                                    "text-[10px] px-1.5 py-0.5 rounded-full font-semibold",
-                                    isAdmin 
-                                      ? "bg-yellow-400/20 text-yellow-400" 
-                                      : "bg-white/10 text-white/40"
-                                  )}>
-                                    {isAdmin ? t('auth.role_admin') : t('auth.role_user')}
+                                  <span
+                                    className={cn(
+                                      'text-[10px] px-1.5 py-0.5 rounded-full font-semibold',
+                                      isAdmin
+                                        ? 'bg-yellow-400/20 text-yellow-400'
+                                        : 'bg-white/10 text-white/40',
+                                    )}
+                                  >
+                                    {isAdmin
+                                      ? t('auth.role_admin')
+                                      : t('auth.role_user')}
                                   </span>
                                 </div>
                                 <p className="text-xs text-white/40 truncate">

--- a/src/lib/effect/i18n/index.ts
+++ b/src/lib/effect/i18n/index.ts
@@ -334,7 +334,37 @@ const dictionary: Record<Locale, Record<string, string>> = {
     "personalization.prompt.term.warm": "la calidez y amabilidad",
     "personalization.prompt.term.enthusiastic": "la energía y emoción",
     "personalization.prompt.term.headers": "el uso de encabezados y listas estructuradas",
-    "personalization.prompt.term.emoji": "el uso de emojis"
+    "personalization.prompt.term.emoji": "el uso de emojis",
+    
+    /** @Logic.I18n.Section.Pricing */
+    "pricing.title": "Planes y Precios",
+    "pricing.subtitle": "Elige el plan que mejor se adapte a tus necesidades. PR\\AI es gratuito hoy, con potencia Pro para el mañana.",
+    "pricing.explanation.title": "Nuestra aplicación utiliza modelos gratuitos de OpenRouter",
+    "pricing.explanation.subtitle": "Nuestro Asistente de Turismo de Puerto Rico utiliza el **Free Models Router** de OpenRouter (`openrouter/free`).",
+    "pricing.how_it_works.title": "¿Cómo funciona? (Explicación sencilla)",
+    "pricing.how_it_works.p1": "Cada vez que envías un mensaje sobre Puerto Rico — ya sea preguntando por las mejores playas, recomendaciones de comida, rutas de senderismo o planificación de viajes — nuestra aplicación dirige automáticamente tu solicitud a través de `openrouter/free`.",
+    "pricing.how_it_works.list_intro": "Este enrutador inteligente:",
+    "pricing.how_it_works.item1": "Verifica qué modelos de IA gratuitos están disponibles en el momento.",
+    "pricing.how_it_works.item2": "Filtra los modelos que pueden manejar correctamente tu solicitud (texto, imágenes, herramientas, etc.).",
+    "pricing.how_it_works.item3": "Selecciona uno al azar de los modelos gratuitos adecuados.",
+    "pricing.how_it_works.item4": "Utiliza ese modelo para generar tu respuesta.",
+    "pricing.details.title": "Detalles clave",
+    "pricing.details.item1": "Completamente gratis ($0 por millón de tokens de entrada y salida).",
+    "pricing.details.item2": "Soporta hasta 200,000 tokens de contexto (ideal para conversaciones detalladas).",
+    "pricing.details.item3": "Lanzado el 1 de febrero de 2026.",
+    "pricing.limits.title": "Límites actuales",
+    "pricing.limits.intro": "Para mantener el servicio gratuito y justo para todos:",
+    "pricing.limits.item1": "Máximo 20 mensajes por minuto.",
+    "pricing.limits.item2": "Aproximadamente 50 mensajes por día.",
+    "pricing.limits.footer": "Estos límites ayudan a evitar sobrecargas para que más personas puedan disfrutar del asistente.",
+    "pricing.future.title": "Próximamente: Plan Pro ✨",
+    "pricing.future.intro": "Estamos planeando añadir un **Plan Pro** en el futuro cercano.",
+    "pricing.future.list_intro": "Con Pro, obtendrás:",
+    "pricing.future.item1": "Acceso a modelos de IA premium más potentes para respuestas mejores y más rápidas.",
+    "pricing.future.item2": "Límites diarios mucho más altos o ilimitados.",
+    "pricing.future.item3": "**Búsqueda web en tiempo real** — la IA podrá traerte información en vivo como el clima actual en San Juan, eventos de hoy, ofertas de vuelos, horarios de restaurantes y las últimas actualizaciones turísticas en todo Puerto Rico.",
+    "pricing.future.footer": "El plan Pro seguirá siendo impulsado por OpenRouter, pero utilizando modelos más avanzados con capacidades en línea.",
+    "pricing.closing": "¡Mantendremos la versión gratuita disponible para que todos puedan seguir explorando Puerto Rico con nuestro asistente de IA! 🌴"
   },
   en: {
     /** @Logic.I18n.Section.Brand */
@@ -665,7 +695,37 @@ const dictionary: Record<Locale, Record<string, string>> = {
     "personalization.prompt.term.warm": "warmth and friendliness",
     "personalization.prompt.term.enthusiastic": "energy and excitement",
     "personalization.prompt.term.headers": "the use of structured headers and lists",
-    "personalization.prompt.term.emoji": "the use of emojis"
+    "personalization.prompt.term.emoji": "the use of emojis",
+
+    /** @Logic.I18n.Section.Pricing */
+    "pricing.title": "Plans & Pricing",
+    "pricing.subtitle": "Choose the plan that best fits your needs. PR\\AI is free today, with Pro power for tomorrow.",
+    "pricing.explanation.title": "Our app uses free OpenRouter models",
+    "pricing.explanation.subtitle": "Our Puerto Rico Tourism Assistant uses **OpenRouter’s Free Models Router** (`openrouter/free`).",
+    "pricing.how_it_works.title": "How it works (simple explanation)",
+    "pricing.how_it_works.p1": "Every time you send a message about Puerto Rico — whether it’s asking for the best beaches, food recommendations, hiking trails, or trip planning — our app automatically routes your request through `openrouter/free`.",
+    "pricing.how_it_works.list_intro": "This smart router:",
+    "pricing.how_it_works.item1": "Checks which free AI models are currently available.",
+    "pricing.how_it_works.item2": "Filters for models that can properly handle your request (text, images, tools, etc.).",
+    "pricing.how_it_works.item3": "Picks one at random from the suitable free models.",
+    "pricing.how_it_works.item4": "Uses that model to generate your reply.",
+    "pricing.details.title": "Key details",
+    "pricing.details.item1": "Completely free ($0 per million input and output tokens).",
+    "pricing.details.item2": "Supports up to 200,000 tokens of context (great for detailed conversations).",
+    "pricing.details.item3": "Released February 1, 2026.",
+    "pricing.limits.title": "Current Limits",
+    "pricing.limits.intro": "To keep the service free and fair for everyone:",
+    "pricing.limits.item1": "Maximum 20 messages per minute.",
+    "pricing.limits.item2": "About 50 messages per day.",
+    "pricing.limits.footer": "These limits help prevent overload so more people can enjoy the assistant.",
+    "pricing.future.title": "Coming Soon: Pro Plan ✨",
+    "pricing.future.intro": "We’re planning to add a **Pro Plan** in the near future.",
+    "pricing.future.list_intro": "With Pro, you’ll get:",
+    "pricing.future.item1": "Access to stronger premium AI models for better and faster responses.",
+    "pricing.future.item2": "Much higher or unlimited daily limits.",
+    "pricing.future.item3": "**Real-time web search** — the AI will be able to bring you live information like current weather in San Juan, today’s events, flight deals, restaurant hours, and the latest tourism updates across Puerto Rico.",
+    "pricing.future.footer": "The Pro plan will still be powered by OpenRouter, but using more advanced models with online capabilities.",
+    "pricing.closing": "We’ll keep the free version available so everyone can continue exploring Puerto Rico with our AI assistant! 🌴"
   }
 }
 


### PR DESCRIPTION
## Summary

Refactor pricing page from client-side fetching to server-side rendering.

## Changes

- Server component loads markdown at build time
- Pass pre-rendered content to client component
- Add `force-static` for CDN caching
- Remove client-side useEffect fetch

## Benefits

- No loading states
- SEO friendly
- Faster (CDN cached)
- Zero JS overhead

Closes #78