### PR TITLE
feat(#112): implement tool calling for Puerto Rico data

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -10,9 +10,10 @@ import { UsageDefaults } from "@/lib/effect/constants/UsageConstants"
 import { SubscriptionTier, SubscriptionDefaults, TierModelConfig, WebSearchPlugins } from "@/lib/effect/constants/SubscriptionConstants"
 import { getUserUsage } from "../user/usage/services/usage"
 import { ChatDbError } from "../_lib/errors/services"
-import { ApiConstants, CacheControlConstants, TimeConstants, SSEConstants } from "@/lib/constants/app-constants"
+import { ApiConstants, CacheControlConstants, SSEConstants } from "@/lib/constants/app-constants"
 import type { SubscriptionTierType, ReasoningEffortType } from "@/lib/effect/constants/SubscriptionConstants"
 import type { Database } from "@/types/database.types"
+import { toolsToOpenRouter, executeTool, validateToolInput, isReadOnlyTool } from "@/lib/effect/services/tools"
 
 type UserUsage = Database["public"]["Functions"]["get_user_usage"]["Returns"][number]
 
@@ -105,6 +106,313 @@ export async function POST(req: Request) {
 
   /** @Logic.Chat.StreamProgram */
   const { searchParams } = new URL(req.url)
+
+  const _buildRequestBody = (messages: { role: string; content: string; name?: string; tool_calls?: unknown[] }[]) => ({
+    model: getModelConfig(auth.tier).default,
+    messages,
+    stream: false,
+    user: auth.userId || undefined,
+    reasoning: {
+      effort: getModelConfig(auth.tier).reasoning.reasoningEffort
+    },
+    tools: toolsToOpenRouter(),
+    ...(auth.tier === SubscriptionTier.Pro ? { plugins: WebSearchPlugins } : {})
+  })
+
+/** @Logic.Chat.ToolCalling.AgenticLoop */
+const AGENTIC_TIMEOUT_MS = 60000
+const MAX_TOOL_ITERATIONS = 5
+const TOOL_EXECUTION_TIMEOUT_MS = 30000
+
+/** @Logic.Chat.RunStreamingAgenticLoop */
+async function runStreamingAgenticLoop(
+  initialMessages: { role: string; content: string; name?: string; tool_calls?: unknown[] }[],
+  userId: string,
+  tier: SubscriptionTierType,
+  onChunk: (chunk: string) => void
+): Promise<{ success: boolean; error?: string }> {
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), AGENTIC_TIMEOUT_MS)
+
+  const buildRequestBody = (msgs: typeof initialMessages) => ({
+    model: getModelConfig(tier).default,
+    messages: msgs,
+    stream: true,
+    user: userId || undefined,
+    reasoning: { effort: getModelConfig(tier).reasoning.reasoningEffort },
+    tools: toolsToOpenRouter(),
+    ...(tier === SubscriptionTier.Pro ? { plugins: WebSearchPlugins } : {})
+  })
+
+  try {
+    let messages = [...initialMessages]
+
+    for (let i = 0; i < MAX_TOOL_ITERATIONS; i++) {
+      console.log(`[StreamToolLoop] Iteration ${i + 1}/${MAX_TOOL_ITERATIONS}`)
+
+      const response = await fetch(ApiConstants.OPENROUTER_CHAT_COMPLETIONS, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${process.env.OPENROUTER_API_KEY}`,
+          'HTTP-Referer': process.env.NEXT_PUBLIC_SITE_URL || '',
+          'X-Title': 'PR\\AI Assistant',
+        },
+        body: JSON.stringify(buildRequestBody(messages)),
+        signal: controller.signal
+      })
+
+      if (!response.ok) {
+        return { success: false, error: `OpenRouter error: ${response.status}` }
+      }
+
+      const streamBody = response.body
+      if (!streamBody) {
+        return { success: false, error: "No stream body" }
+      }
+
+      const decoder = new TextDecoder()
+      const reader = streamBody.getReader()
+      let buffer = ''
+      let toolCallsBuffer: unknown[] = []
+      let hasToolCalls = false
+
+      while (true) {
+        const { done, value } = await reader.read()
+
+        if (done) {
+          if (buffer.length > 0) {
+            onChunk(buffer)
+          }
+          break
+        }
+
+        buffer += decoder.decode(value, { stream: true })
+        const lines = buffer.split('\n')
+        buffer = lines.pop() || ''
+
+        for (const line of lines) {
+          if (!line.startsWith(SSEConstants.DATA_PREFIX)) {
+            onChunk(line + '\n')
+            continue
+          }
+
+          const data = line.slice(SSEConstants.DATA_PREFIX.length)
+          if (data === SSEConstants.DONE) continue
+
+          try {
+            const parsed = JSON.parse(data)
+            const delta = parsed.choices?.[0]?.delta
+
+            if (delta?.tool_calls) {
+              hasToolCalls = true
+              toolCallsBuffer.push(...delta.tool_calls)
+            }
+
+            if (delta?.content) {
+              onChunk(line + '\n')
+            }
+          } catch {
+            onChunk(line + '\n')
+          }
+        }
+      }
+
+      if (!hasToolCalls || toolCallsBuffer.length === 0) {
+        clearTimeout(timeoutId)
+        return { success: true }
+      }
+
+      console.log(`[StreamToolLoop] Executing ${toolCallsBuffer.length} tool(s)`)
+
+      const toolMessages: { role: string; tool_call_id: string; name: string; content: string }[] = []
+
+      for (const tc of toolCallsBuffer) {
+        const { id, function: fn } = tc as { id: string; function: { name: string; arguments: string } }
+        const toolName = fn.name
+        const args = JSON.parse(fn.arguments)
+
+        const validation = validateToolInput(toolName, args)
+        let toolResult: string
+
+        if (!validation.success) {
+          toolResult = JSON.stringify({ error: validation.error })
+        } else {
+          try {
+            const execResult = await Effect.runPromise(
+              Effect.timeout(executeTool(toolName, validation.parsed || args), TOOL_EXECUTION_TIMEOUT_MS)
+            )
+            toolResult = execResult
+          } catch (execError) {
+            console.error(`[StreamToolLoop] Tool error: ${toolName}`, execError)
+            toolResult = JSON.stringify({ error: `Tool execution failed: ${String(execError)}` })
+          }
+        }
+
+        toolMessages.push({
+          role: "tool",
+          tool_call_id: id,
+          name: toolName,
+          content: toolResult
+        })
+
+        const toolResultLine = SSEConstants.DATA_PREFIX + JSON.stringify({
+          choices: [{ delta: { role: "tool", content: toolResult }, finish_reason: null }]
+        }) + '\n'
+        onChunk(toolResultLine)
+      }
+
+      messages = [
+        ...messages,
+        { role: "assistant", content: "", tool_calls: toolCallsBuffer },
+        ...toolMessages
+      ]
+
+      const doneLine = SSEConstants.DATA_PREFIX + SSEConstants.DONE + '\n'
+      onChunk(doneLine)
+
+      toolCallsBuffer = []
+    }
+
+    clearTimeout(timeoutId)
+    return { success: true }
+  } catch (error) {
+    clearTimeout(timeoutId)
+    const isAbort = error instanceof DOMException && error.name === 'AbortError'
+    console.error(`[StreamToolLoop] ${isAbort ? 'Timeout' : 'Error'}`, error)
+    return { success: false, error: isAbort ? "Request timeout" : String(error) }
+  }
+}
+
+const runAgenticLoop = async (
+  initialMessages: { role: string; content: string; name?: string; tool_calls?: unknown[] }[],
+  userId: string,
+  tier: SubscriptionTierType
+): Promise<{ success: boolean; data?: unknown; error?: string }> => {
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), AGENTIC_TIMEOUT_MS)
+
+  try {
+    const buildRequestBody = (msgs: typeof initialMessages) => ({
+      model: getModelConfig(tier).default,
+      messages: msgs,
+      stream: false,
+      user: userId || undefined,
+      reasoning: {
+        effort: getModelConfig(tier).reasoning.reasoningEffort
+      },
+      tools: toolsToOpenRouter(),
+      ...(tier === SubscriptionTier.Pro ? { plugins: WebSearchPlugins } : {})
+    })
+
+    let messages = [...initialMessages]
+
+    for (let i = 0; i < MAX_TOOL_ITERATIONS; i++) {
+      console.log(`[ToolLoop] Iteration ${i + 1}/${MAX_TOOL_ITERATIONS}`)
+
+      const response = await fetch(ApiConstants.OPENROUTER_CHAT_COMPLETIONS, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${process.env.OPENROUTER_API_KEY}`,
+          'HTTP-Referer': process.env.NEXT_PUBLIC_SITE_URL || '',
+          'X-Title': 'PR\\AI Assistant',
+        },
+        body: JSON.stringify(buildRequestBody(messages)),
+        signal: controller.signal
+      })
+
+      if (!response.ok) {
+        const errorBody = await response.text()
+        console.error(`[ToolLoop] OpenRouter error: ${response.status}`, errorBody)
+        return { success: false, error: `OpenRouter error: ${response.status}` }
+      }
+
+      const data = await response.json()
+      const assistantMessage = data.choices?.[0]?.message
+
+      if (!assistantMessage) {
+        return { success: true, data }
+      }
+
+      const toolCalls = assistantMessage.tool_calls || []
+
+      if (toolCalls.length === 0) {
+        return { success: true, data }
+      }
+
+      console.log(`[ToolLoop] Executing ${toolCalls.length} tool(s)`)
+
+      const toolMessages: { role: string; tool_call_id: string; name: string; content: string }[] = []
+
+      const parsedToolCalls: Array<{ id: string; name: string; args: Record<string, unknown> }> = toolCalls.map((tc: { id: string; function: { name: string; arguments: string } }) => {
+        const { id, function: fn } = tc
+        return { id, name: fn.name, args: JSON.parse(fn.arguments) }
+      })
+
+      const readOnlyCalls = parsedToolCalls.filter((tc: { name: string }) => isReadOnlyTool(tc.name))
+      const writeCalls = parsedToolCalls.filter((tc: { name: string }) => !isReadOnlyTool(tc.name))
+
+      const executeToolCall = async (id: string, toolName: string, args: Record<string, unknown>): Promise<string> => {
+        const validation = validateToolInput(toolName, args)
+        if (!validation.success) {
+          return JSON.stringify({ error: validation.error })
+        }
+        try {
+          const execResult = await Effect.runPromise(
+            Effect.timeout(executeTool(toolName, validation.parsed || args), TOOL_EXECUTION_TIMEOUT_MS)
+          )
+          return execResult
+        } catch (execError) {
+          console.error(`[ToolLoop] Tool execution error: ${toolName}`, execError)
+          return JSON.stringify({ error: `Tool execution failed: ${String(execError)}` })
+        }
+      }
+
+      if (readOnlyCalls.length > 0) {
+        const readOnlyResults = await Promise.all(
+          readOnlyCalls.map(async (tc: { id: string; name: string; args: Record<string, unknown> }) => {
+            const result = await executeToolCall(tc.id, tc.name, tc.args)
+            return { id: tc.id, name: tc.name, content: result }
+          })
+        )
+        toolMessages.push(...readOnlyResults.map(r => ({
+          role: "tool" as const,
+          tool_call_id: r.id,
+          name: r.name,
+          content: r.content
+        })))
+      }
+
+      for (const tc of writeCalls) {
+        const result = await executeToolCall(tc.id, tc.name, tc.args)
+        toolMessages.push({
+          role: "tool",
+          tool_call_id: tc.id,
+          name: tc.name,
+          content: result
+        })
+      }
+
+      messages = [
+        ...messages,
+        { role: "assistant", content: assistantMessage.content || "", tool_calls: toolCalls },
+        ...toolMessages
+      ]
+    }
+
+    console.warn(`[ToolLoop] Max iterations reached (${MAX_TOOL_ITERATIONS})`)
+    return { success: false, error: "Max tool iterations reached" }
+
+  } catch (error) {
+    const isAbort = error instanceof DOMException && error.name === 'AbortError'
+    console.error(`[ToolLoop] ${isAbort ? 'Timeout' : 'Error'}`, error)
+    return { success: false, error: isAbort ? "Request timeout" : String(error) }
+  } finally {
+    clearTimeout(timeoutId)
+  }
+}
+
   const program = pipe(
     decodeBody(
       S.Struct({
@@ -120,48 +428,14 @@ export async function POST(req: Request) {
       })
     )(req),
     Effect.flatMap((params) => {
-      /** @Logic.Chat.ModelResolution */
-      const modelConfig = getModelConfig(auth.tier)
-      const tierModel = modelConfig.default
-      const model = params.model || tierModel
-
-      const requestBody: Record<string, unknown> = {
-        model,
-        messages: params.messages,
-        stream: params.stream ?? true,
-        user: auth.userId || undefined,
-        reasoning: {
-          effort: modelConfig.reasoning.reasoningEffort
-        }
-      }
-
-      /** @Logic.Chat.InjectPlugins */
-      if (auth.tier === SubscriptionTier.Pro) {
-        requestBody.plugins = WebSearchPlugins
-      }
-
       /** @Logic.Chat.OpenRouterInvocation */
       return Effect.tryPromise({
         try: async () => {
-          const response = await fetch(ApiConstants.OPENROUTER_CHAT_COMPLETIONS, {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              'Authorization': `Bearer ${process.env.OPENROUTER_API_KEY}`,
-              'HTTP-Referer': process.env.NEXT_PUBLIC_SITE_URL || '',
-              'X-Title': 'PR\\AI Assistant',
-            },
-            body: JSON.stringify(requestBody),
-          })
-
-          if (!response.ok) {
-            throw new Error('OpenRouter error')
-          }
-
-          /** @Logic.Chat.SyncUsageTracking */
-          if (!(params.stream ?? true)) {
-            const data = await response.json()
-            const usageData = data.usage || {}
+          const isStreaming = params.stream ?? true
+          
+          if (!isStreaming) {
+            const result = await runAgenticLoop([...params.messages], auth.userId, auth.tier)
+            const usageData = result.data && typeof result.data === 'object' ? (result.data as { usage?: { total_tokens?: number; cost?: number } }).usage || {} : {}
             const totalTokens = usageData.total_tokens || 0
             const cost = usageData.cost || 0
 
@@ -170,87 +444,43 @@ export async function POST(req: Request) {
                 await fetch(`${process.env.NEXT_PUBLIC_SITE_URL || ''}/api/user/usage/increment`, {
                   method: 'POST',
                   headers: { 'Content-Type': 'application/json' },
-                  body: JSON.stringify({
-                    amount: 1,
-                    tokens: totalTokens,
-                    cost: cost
-                  })
+                  body: JSON.stringify({ amount: 1, tokens: totalTokens, cost })
                 })
-              } catch {
-                /** @Logic.Chat.SilentFailure */
-              }
+              } catch { /** @Logic.Chat.SilentFailure */ }
             }
 
-            return NextResponse.json(data)
+            return result.success 
+              ? NextResponse.json(result.data)
+              : NextResponse.json({ error: result.error }, { status: HttpStatus.INTERNAL_SERVER_ERROR })
           }
 
-          /** @Logic.Chat.StreamUsageTracking */
-          const userId = auth.userId
-          const responseBody = response.body
+          const initialMessages = [...params.messages]
           
-          if (!responseBody) {
-            return new Response(null, { status: HttpStatus.INTERNAL_SERVER_ERROR })
-          }
-
           const encoder = new TextEncoder()
-          const decoder = new TextDecoder()
-          let buffer = ''
-          
+
           const transformStream = new ReadableStream({
             async start(controller) {
-              const reader = responseBody.getReader()
-              
               try {
-                while (true) {
-                  const { done, value } = await reader.read()
-                  
-                  if (done) {
-                    if (buffer.length > 0 && userId) {
-                      const lines = buffer.split('\n')
-                      for (const line of lines) {
-                        if (line.startsWith(SSEConstants.DATA_PREFIX)) {
-                          const data = line.slice(SSEConstants.DATA_PREFIX.length)
-                          if (data === SSEConstants.DONE) continue
-                          try {
-                            const parsed = JSON.parse(data)
-                            if (parsed.usage) {
-                              const totalTokens = parsed.usage.total_tokens || 0
-                              const cost = parsed.usage.cost || 0
-                              if (totalTokens > 0) {
-                                fetch(`${process.env.NEXT_PUBLIC_SITE_URL || ''}/api/user/usage/increment`, {
-                                  method: 'POST',
-                                  headers: { 'Content-Type': 'application/json' },
-                                  body: JSON.stringify({ amount: 1, tokens: totalTokens, cost })
-                                }).catch(() => { })
-                              }
-                            }
-                          } catch { /** @Logic.Chat.IgnoreParseErrors */ }
-                        }
-                      }
-                    }
-
-                    /** @Logic.Chat.UsageTrackingFallback */
-                    if (userId) {
-                      setTimeout(() => {
-                        fetch(`${process.env.NEXT_PUBLIC_SITE_URL || ''}/api/user/usage/increment`, {
-                          method: 'POST',
-                          headers: { 'Content-Type': 'application/json' },
-                          body: JSON.stringify({ amount: 1, tokens: 0, cost: 0 })
-                        }).catch(() => { })
-                      }, TimeConstants.USAGE_TRACK_DEBOUNCE_MS)
-                    }
-                    controller.close()
-                    break
-                  }
-                  
-                  buffer += decoder.decode(value, { stream: true })
-                  const lines = buffer.split('\n')
-                  buffer = lines.pop() || ''
-                  
-                  for (const line of lines) {
-                    controller.enqueue(encoder.encode(line + '\n'))
-                  }
+                const onChunk = (chunk: string) => {
+                  controller.enqueue(encoder.encode(chunk))
                 }
+
+                const result = await runStreamingAgenticLoop(
+                  initialMessages,
+                  auth.userId,
+                  auth.tier,
+                  onChunk
+                )
+
+                if (!result.success) {
+                  const errorChunk = SSEConstants.DATA_PREFIX + JSON.stringify({
+                    choices: [{ delta: { content: `[Error: ${result.error}]` }, finish_reason: "stop" }]
+                  }) + '\n'
+                  controller.enqueue(encoder.encode(errorChunk))
+                }
+
+                controller.enqueue(encoder.encode(SSEConstants.DATA_PREFIX + SSEConstants.DONE + '\n'))
+                controller.close()
               } catch (error) {
                 controller.error(error)
               }

--- a/src/app/api/chat/schemas/message.schemas.ts
+++ b/src/app/api/chat/schemas/message.schemas.ts
@@ -4,17 +4,21 @@ import { S } from "../../_lib/validation"
 export const ChatMessageRoleSchema = S.Literal("user", "assistant")
 export type ChatMessageRole = S.Schema.Type<typeof ChatMessageRoleSchema>
 
-export const MessageContentSchema = S.String.pipe(
-  S.filter((s: string) => s.trim().length > 0, { message: () => "content is required" })
-)
-
+/** @Schema.Api.Chat.CreateMessage */
 export const CreateMessageSchema = S.Struct({
   chatId: S.String.pipe(
     S.filter((s: string) => s.trim().length > 0, { message: () => "chatId is required" })
   ),
   role: ChatMessageRoleSchema,
-  content: MessageContentSchema,
-  metadata: S.Union(S.Null, S.Undefined, S.Unknown)
-})
+  /** @Schema.Api.Chat.Content */
+  content: S.String,
+  metadata: S.Union(S.Null, S.Undefined, S.Unknown),
+}).pipe(
+  S.filter(
+    (msg) => msg.role === "assistant" || msg.content.trim().length > 0,
+    { message: () => "content is required for user messages" }
+  )
+)
 
 export type CreateMessage = S.Schema.Type<typeof CreateMessageSchema>
+

--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -10,7 +10,9 @@ import { motion, AnimatePresence } from 'framer-motion'
 import { cn } from '@/lib/utils'
 import { useAppDispatch } from '@/store/hooks'
 import { openSources } from '@/store/slices/chatSlice'
-import { ChatRole, type ChatMessage, type SearchResult } from '@/types/chat'
+import { ChatRole } from '@/types/chat'
+import type { ChatMessage } from '@/lib/effect/schemas/ChatSchema'
+import type { SearchResult } from '@/lib/effect/schemas/ChatSchema'
 import {
   Copy,
   ChevronRight,
@@ -23,23 +25,17 @@ import {
   X,
 } from 'lucide-react'
 
+/** @Constant.UI.Chat.MarkdownRenderer */
 const md = new MarkdownIt({
   html: true,
   linkify: true,
   typographer: true,
 })
 
+/** @Type.UI.Chat.Bubble.Props */
 interface MessageBubbleProps {
-  message: ChatMessage & {
-    metadata?: {
-      thought?: string
-      thoughtDuration?: string
-      steps?: { type: 'analyzed' | 'plan' | 'search'; label: string }[]
-      sources?: SearchResult[]
-      searchQuery?: string
-      edited?: boolean
-    }
-  }
+  /** @Type.UI.Chat.Message */
+  message: ChatMessage
   index: number
   onEdit?: (index: number, content: string) => void
   onStop?: () => void
@@ -131,7 +127,7 @@ export const MessageBubble: React.FC<MessageBubbleProps> = memo(({ message, inde
           <div className="absolute -top-1 w-full flex justify-end pointer-events-none z-10">
             <button
               onClick={copyToClipboard}
-              className="pointer-events-auto px-2 py-1 flex items-center gap-1.5 text-white/20 hover:text-white/60 transition-all rounded-lg hover:bg-white/5 active:scale-95 text-[11px] font-bold uppercase tracking-widest"
+              className="pointer-events-auto px-2.5 py-1.5 flex items-center gap-1.5 text-white/30 hover:text-white/70 transition-all rounded-lg hover:bg-white/5 active:scale-95 text-[12px] font-medium tracking-tight"
             >
               {isCopied ? (
                 <>
@@ -217,9 +213,12 @@ export const MessageBubble: React.FC<MessageBubbleProps> = memo(({ message, inde
                       {(() => {
                         const val = message.metadata?.thoughtDuration
                         if (!val) return t('chat.thinking')
+                        
                         if (val.startsWith('status:')) {
-                          return `${t('chat.thinking.prefix')} ${t(val.split(':')[1] || 'chat.thinking.analyzing')}`
+                          const statusKey = val.split(':')[1] || 'analyzing'
+                          return `${t('chat.thinking.prefix')} ${t(`chat.thinking.${statusKey}`)}...`
                         }
+                        
                         if (val.startsWith('completed:')) {
                           return `${t('chat.thinking.completed')} ${val.split(':')[1] || ''}`
                         }
@@ -289,6 +288,33 @@ export const MessageBubble: React.FC<MessageBubbleProps> = memo(({ message, inde
                   <span className="text-[14px] tracking-tight">{step.label}</span>
                 </div>
               ))}
+
+              {message.metadata?.tool_calls && message.metadata.tool_calls.length > 0 && (
+                <div className="flex flex-col gap-3 py-3">
+                  <div className="flex items-center gap-2 text-[13px] font-black text-white/30 uppercase tracking-[0.2em] mb-1">
+                    <Search className="w-3.5 h-3.5" />
+                    <span>{t('chat.tools') || 'Herramientas'}</span>
+                  </div>
+                  <div className="flex flex-col gap-2">
+                    {message.metadata.tool_calls.map((tc, idx) => (
+                      <div
+                        key={idx}
+                        className="flex items-center gap-3 px-4 py-2.5 bg-white/[0.03] border border-white/10 rounded-2xl text-[14px] shadow-sm hover:bg-white/[0.05] transition-all"
+                      >
+                        <div className="flex items-center gap-2 text-orange-400 font-bold shrink-0">
+                          <span className="w-1.5 h-1.5 rounded-full bg-orange-400 animate-pulse" />
+                          <span>{tc.name}</span>
+                        </div>
+                        {tc.result && (
+                          <div className="text-white/40 text-[13px] truncate border-l border-white/10 pl-3">
+                            {typeof tc.result === 'string' ? tc.result : JSON.stringify(tc.result)}
+                          </div>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
             </div>
 
             <div

--- a/src/hooks/useAiSuggestions.ts
+++ b/src/hooks/useAiSuggestions.ts
@@ -3,27 +3,33 @@
 /** @Hook.UseAiSuggestions */
 
 import { useState, useEffect, useRef, useCallback } from 'react'
+import { Effect, Exit, Stream, Cause } from 'effect'
 import type { ChatMessage } from '@/types/chat'
 import { ChatRole } from '@/types/chat'
-import { 
-  shouldShowSuggestion, 
-  buildSuggestionPrompt, 
-  processSuggestionResponse, 
+import { SuggestionError } from '@/lib/effect/errors'
+import type { SuggestionMessage } from '@/lib/effect/schemas/SuggestionSchema'
+import {
+  shouldShowSuggestion,
+  buildSuggestionPrompt,
+  processSuggestionResponse,
   getSuggestionSystemPrompt,
-  SUGGESTION_CONFIG
+  SUGGESTION_GENERATE_TOKEN,
+  SUGGESTION_CONFIG,
 } from '@/lib/effect/services/Suggestion'
 import { runtime } from '@/lib/effect/runtime'
 import { OpenRouter } from '@/lib/effect/services/OpenRouter'
-import { Effect, Stream } from 'effect'
 
 /** @Hook.UseAiSuggestions */
 export function useAiSuggestions(messages: readonly ChatMessage[], isLoading: boolean) {
   /** @State.Suggestions */
   const [aiSuggestions, setAiSuggestions] = useState<string[]>([])
+
   /** @Ref.AbortController */
   const abortControllerRef = useRef<AbortController | null>(null)
+
   /** @Ref.IsMounted */
   const isMountedRef = useRef(true)
+
   /** @Ref.LastRequestTime */
   const lastRequestTimeRef = useRef<number>(0)
 
@@ -32,19 +38,52 @@ export function useAiSuggestions(messages: readonly ChatMessage[], isLoading: bo
     isMountedRef.current = true
     return () => {
       isMountedRef.current = false
-      if (abortControllerRef.current) {
-        abortControllerRef.current.abort()
-      }
+      abortControllerRef.current?.abort()
     }
   }, [])
 
   /** @Logic.Suggestion.AbortPrevious */
-  const abortPrevious = useCallback(() => {
-    if (abortControllerRef.current) {
-      abortControllerRef.current.abort()
-    }
-    abortControllerRef.current = new AbortController()
+  const abortPrevious = useCallback((): AbortController => {
+    abortControllerRef.current?.abort()
+    const controller = new AbortController()
+    abortControllerRef.current = controller
+    return controller
   }, [])
+
+  /** @Logic.Suggestion.BuildEffect */
+  const buildSuggestionEffect = useCallback(
+    (promptMessages: SuggestionMessage[]) =>
+      Effect.gen(function* () {
+        /** @Effect.Suggestion.GetService */
+        const or = yield* OpenRouter
+
+        /** @Effect.Suggestion.Stream */
+        const stream = or.chat(promptMessages)
+
+        /** @Effect.Suggestion.Collect */
+        const chunks = yield* Stream.runCollect(Stream.take(stream, 1))
+
+        /** @Effect.Suggestion.Aggregate */
+        let raw = ''
+        for (const chunk of chunks) {
+          raw += chunk.content
+        }
+
+        /** @Effect.Suggestion.Process */
+        return yield* processSuggestionResponse(raw)
+      }).pipe(
+        Effect.mapError((err) => {
+          /** @Error.Suggestion.MapGeneration */
+          if (err instanceof SuggestionError) return err
+          return new SuggestionError({
+            message: String(err),
+            reason: 'generation',
+            cause: err,
+          })
+        }),
+      ),
+    [],
+  )
 
   /** @Hook.Effect.Trigger */
   useEffect(() => {
@@ -56,10 +95,7 @@ export function useAiSuggestions(messages: readonly ChatMessage[], isLoading: bo
 
     /** @Check.RateLimit */
     const now = Date.now()
-    const timeSinceLastRequest = now - lastRequestTimeRef.current
-    if (timeSinceLastRequest < SUGGESTION_CONFIG.RATE_LIMIT_MS) {
-      return
-    }
+    if (now - lastRequestTimeRef.current < SUGGESTION_CONFIG.RATE_LIMIT_MS) return
 
     /** @Check.ShouldShow */
     if (!shouldShowSuggestion(messages)) {
@@ -68,71 +104,53 @@ export function useAiSuggestions(messages: readonly ChatMessage[], isLoading: bo
     }
 
     /** @Logic.Suggestion.Generate */
-    const generateAISuggestion = async () => {
-      /** @Logic.AbortPrevious */
+    const generate = async () => {
       abortPrevious()
-      /** @Logic.UpdateLastRequestTime */
       lastRequestTimeRef.current = Date.now()
 
-      try {
-        /** @Logic.BuildPrompt */
-        const prompt = buildSuggestionPrompt(messages)
-        /** @Logic.GetSystemPrompt */
-        const systemPrompt = getSuggestionSystemPrompt()
-        
-        /** @Logic.BuildMessages */
-        const suggestionMessages: Array<{ role: typeof ChatRole[keyof typeof ChatRole]; content: string }> = [
-          { role: ChatRole.SYSTEM, content: systemPrompt + '\n\n' + prompt },
-          { role: ChatRole.USER, content: '[Generar sugerencia]' }
-        ]
-        
-        /** @Effect.RunAI */
-        const runEffect = Effect.gen(function* () {
-          const or = yield* OpenRouter
-          const stream = or.chat(suggestionMessages)
-          const collected = yield* Stream.runCollect(Stream.take(stream, 1))
-          let content = ''
-          for (const response of collected) {
-            content += response.content
-          }
-          return content
-        })
-        
-        /** @Logic.RunEffect */
-        const result = await runtime.runPromise(
-          Effect.provide(runEffect, OpenRouter.Default)
-        )
-        
-        /** @Check.Mounted */
-        if (!isMountedRef.current) return
-        
-        /** @Logic.ProcessResponse */
-        const processed = processSuggestionResponse(result)
-        
-        /** @Check.Confidence */
-        if (
-          processed.suggestion && 
-          processed.confidence >= SUGGESTION_CONFIG.CONFIDENCE_THRESHOLD
-        ) {
-          setAiSuggestions([processed.suggestion])
-        } else {
-          setAiSuggestions([])
-        }
-      } catch (err) {
-        /** @Check.Mounted */
-        if (!isMountedRef.current) return
-        /** @Check.AbortError */
-        if (err instanceof Error && err.name === 'AbortError') return
-        
-        setAiSuggestions([])
-      }
-    }
-    
-    /** @Logic.Generate */
-    generateAISuggestion()
-  }, [isLoading, messages, abortPrevious])
+      /** @Logic.Suggestion.BuildMessages */
+      const systemPrompt = getSuggestionSystemPrompt()
+      const contextPrompt = buildSuggestionPrompt(messages)
 
-  /** @Logic.ClearSuggestions */
+      const promptMessages: SuggestionMessage[] = [
+        { role: ChatRole.SYSTEM, content: `${systemPrompt}\n\n${contextPrompt}` },
+        { role: ChatRole.USER, content: SUGGESTION_GENERATE_TOKEN },
+      ]
+
+      /** @Logic.Suggestion.RunEffect */
+      const exit = await runtime.runPromiseExit(buildSuggestionEffect(promptMessages))
+
+      /** @Check.Mounted */
+      if (!isMountedRef.current) return
+
+      /** @Logic.Suggestion.HandleExit */
+      Exit.match(exit, {
+        onSuccess: (result) => {
+          setAiSuggestions([result.suggestion])
+        },
+        onFailure: (cause) => {
+          /** @Logic.Suggestion.HandleFailure */
+          const maybeErr = Cause.failureOption(cause)
+          if (maybeErr._tag === 'Some') {
+            const suggErr = maybeErr.value
+            /** @Check.Abort */
+            if (suggErr instanceof SuggestionError) {
+              if (
+                suggErr.reason === 'aborted' ||
+                suggErr.reason === 'rate_limit' ||
+                suggErr.reason === 'unmounted'
+              ) return
+            }
+          }
+          setAiSuggestions([])
+        },
+      })
+    }
+
+    generate()
+  }, [isLoading, messages, abortPrevious, buildSuggestionEffect])
+
+  /** @Logic.Suggestion.Clear */
   const clearSuggestions = useCallback(() => {
     setAiSuggestions([])
     abortPrevious()
@@ -142,6 +160,6 @@ export function useAiSuggestions(messages: readonly ChatMessage[], isLoading: bo
   return {
     aiSuggestions,
     clearSuggestions,
-    setAiSuggestions
+    setAiSuggestions,
   }
 }

--- a/src/lib/effect/chat.ts
+++ b/src/lib/effect/chat.ts
@@ -1,6 +1,7 @@
 import { Effect, Ref, Stream } from "effect"
 import type { SearchResult } from "@/types/chat"
-import { OpenRouter, type ChatResponse } from "./services/OpenRouter"
+import { OpenRouter } from "./services/OpenRouter"
+import type { ChatResponse } from "./schemas/OpenRouterSchema"
 import { ConfigService } from "./services/Config"
 import { Redux } from "./services/Redux"
 import { ChatApi } from "./services/ChatApi"
@@ -98,6 +99,7 @@ const generateResponse = (
   /** @Logic.Chat.Refs */
   const contentRef = yield* Ref.make("")
   const reasoningRef = yield* Ref.make("")
+  const toolCallsRef = yield* Ref.make<Array<{ id: string; name: string; arguments: string; result?: string }>>([])
 
   /** @Logic.Chat.SourceTracking */
   const sourcesRef = yield* Ref.make<SearchResult[]>([])
@@ -116,6 +118,7 @@ const generateResponse = (
       const content = response.content
       const reasoning = response.reasoning
       const annotations = response.annotations
+      const toolCalls = response.toolCalls
 
       /** @Logic.Chat.ProcessReasoning */
       if (reasoning) {
@@ -123,6 +126,21 @@ const generateResponse = (
         const currentReasoning = yield* Ref.get(reasoningRef)
         yield* Redux.dispatch(updateLastMessage({
           metadata: { thought: currentReasoning, isThinking: true }
+        }))
+      }
+
+      /** @Logic.Chat.ProcessToolCalls */
+      if (toolCalls && toolCalls.length > 0) {
+        const toolCallMetadata = toolCalls.map(tc => ({
+          id: tc.id,
+          name: tc.name,
+          arguments: tc.arguments
+        }))
+        const currentMeta = yield* Redux.getState().pipe(
+          Effect.map(s => s.chat.messages[s.chat.messages.length - 1]?.metadata)
+        )
+        yield* Redux.dispatch(updateLastMessage({
+          metadata: { ...currentMeta, tool_calls: toolCallMetadata }
         }))
       }
 

--- a/src/lib/effect/errors.ts
+++ b/src/lib/effect/errors.ts
@@ -59,3 +59,18 @@ export class ChangelogError extends Data.TaggedError("ChangelogError")<{
   readonly message: string
   readonly cause?: unknown
 }> {}
+
+/** @Error.Effect.Tool */
+export class ToolError extends Data.TaggedError("ToolError")<{
+  readonly toolName: string
+  readonly message: string
+  readonly cause?: unknown
+}> {}
+
+/** @Error.Effect.Suggestion */
+export class SuggestionError extends Data.TaggedError("SuggestionError")<{
+  readonly message: string
+  readonly reason: "generation" | "filter" | "rate_limit" | "unmounted" | "aborted"
+  readonly filterReason?: string
+  readonly cause?: unknown
+}> {}

--- a/src/lib/effect/i18n/index.ts
+++ b/src/lib/effect/i18n/index.ts
@@ -117,6 +117,7 @@ const dictionary: Record<Locale, Record<string, string>> = {
     "chat.no_archived": "Sin conversaciones archivadas",
     "chat.archived_title": "Archivadas",
     "chat.back_to_menu": "Volver",
+    "chat.tools": "Herramientas",
 
     /** @Logic.I18n.Section.Issues */
     "issues.title": "Reportar un Error",
@@ -553,6 +554,7 @@ const dictionary: Record<Locale, Record<string, string>> = {
     "chat.no_archived": "No archived conversations",
     "chat.archived_title": "Archived",
     "chat.back_to_menu": "Back",
+    "chat.tools": "Tools",
 
     /** @Logic.I18n.Section.Issues */
     "issues.title": "Report a Bug",

--- a/src/lib/effect/runtime.ts
+++ b/src/lib/effect/runtime.ts
@@ -1,7 +1,7 @@
 import { Layer, ManagedRuntime, ConfigProvider, Effect } from "effect";
 import { BrowserHttpClient } from "@effect/platform-browser";
 import { ConfigService } from "./services/Config";
-import { OpenRouter } from "./services/OpenRouter";
+import { OpenRouter, OpenRouterLayer } from "./services/OpenRouter";
 import { Redux } from "./services/Redux";
 import { PromptBuilderService } from "./services/PromptBuilder";
 import { VoiceServiceLive } from "./services/Voice";
@@ -47,7 +47,7 @@ const MainLayer = Layer.mergeAll(
   SeoService.Default.pipe(
     Layer.provideMerge(ConfigLayer)
   ),
-  OpenRouter.Default.pipe(
+  OpenRouterLayer.pipe(
     Layer.provideMerge(ConfigLayer),
     Layer.provideMerge(BaseLayer)
   )

--- a/src/lib/effect/schemas/AdaptiveCardsSchema.ts
+++ b/src/lib/effect/schemas/AdaptiveCardsSchema.ts
@@ -222,3 +222,11 @@ export const AdaptiveCardTypeSchema = Schema.Literal(
 )
 
 export type CardType = Schema.Schema.Type<typeof AdaptiveCardTypeSchema>
+/** @Schema.Effect.AdaptiveCards.Data */
+export const AdaptiveDataSchema = Schema.Struct({
+  type: AdaptiveCardTypeSchema,
+  data: Schema.Unknown,
+})
+
+/** @Type.Effect.AdaptiveCards.Data */
+export type AdaptiveData = Schema.Schema.Type<typeof AdaptiveDataSchema>

--- a/src/lib/effect/schemas/ChatSchema.ts
+++ b/src/lib/effect/schemas/ChatSchema.ts
@@ -1,0 +1,62 @@
+import { Schema } from "effect"
+
+/** @Schema.Effect.Chat.SearchResult */
+export const SearchResultSchema = Schema.Struct({
+  title: Schema.String,
+  url: Schema.String,
+  snippet: Schema.optional(Schema.String),
+  source: Schema.optional(Schema.String),
+  icon: Schema.optional(Schema.String),
+  verified: Schema.optional(Schema.Boolean),
+})
+
+/** @Type.Effect.Chat.SearchResult */
+export type SearchResult = Schema.Schema.Type<typeof SearchResultSchema>
+
+/** @Schema.Effect.Chat.MessageStep */
+export const MessageStepSchema = Schema.Struct({
+  type: Schema.Literal("analyzed", "plan", "search"),
+  label: Schema.String,
+})
+
+/** @Type.Effect.Chat.MessageStep */
+export type MessageStep = Schema.Schema.Type<typeof MessageStepSchema>
+
+/** @Schema.Effect.Chat.ToolCallRecord */
+export const ToolCallRecordSchema = Schema.Struct({
+  id: Schema.String,
+  name: Schema.String,
+  arguments: Schema.String,
+  result: Schema.optional(Schema.String),
+})
+
+/** @Type.Effect.Chat.ToolCallRecord */
+export type ToolCallRecord = Schema.Schema.Type<typeof ToolCallRecordSchema>
+
+/** @Schema.Effect.Chat.MessageMetadata */
+export const ChatMessageMetadataSchema = Schema.Struct({
+  thought: Schema.optional(Schema.String),
+  thoughtTime: Schema.optional(Schema.String),
+  isThinking: Schema.optional(Schema.Boolean),
+  thoughtDuration: Schema.optional(Schema.String),
+  steps: Schema.optional(Schema.Array(MessageStepSchema)),
+  sources: Schema.optional(Schema.Array(SearchResultSchema)),
+  searchQuery: Schema.optional(Schema.String),
+  edited: Schema.optional(Schema.Boolean),
+  tool_calls: Schema.optional(Schema.Array(ToolCallRecordSchema)),
+})
+
+/** @Type.Effect.Chat.MessageMetadata */
+export type ChatMessageMetadata = Schema.Schema.Type<typeof ChatMessageMetadataSchema>
+
+const ChatRoleSchema = Schema.Literal("user", "assistant", "system")
+
+/** @Schema.Effect.Chat.Message */
+export const ChatMessageSchema = Schema.Struct({
+  role: ChatRoleSchema,
+  content: Schema.String,
+  metadata: Schema.optional(ChatMessageMetadataSchema),
+})
+
+/** @Type.Effect.Chat.Message */
+export type ChatMessage = Schema.Schema.Type<typeof ChatMessageSchema>

--- a/src/lib/effect/schemas/OpenRouterSchema.ts
+++ b/src/lib/effect/schemas/OpenRouterSchema.ts
@@ -1,6 +1,6 @@
 import { Schema } from "effect"
 
-/** @Schema.Effect.OpenRouter */
+/** @Schema.Effect.OpenRouter.ChatMessage */
 export const ChatMessageSchema = Schema.Struct({
   role: Schema.Literal("user", "assistant", "system"),
   content: Schema.String
@@ -8,7 +8,7 @@ export const ChatMessageSchema = Schema.Struct({
 
 export type ChatMessage = Schema.Schema.Type<typeof ChatMessageSchema>
 
-
+/** @Schema.Effect.OpenRouter.RateLimit */
 export const OpenRouterRateLimitSchema = Schema.Struct({
   headers: Schema.Struct({
     "X-RateLimit-Limit": Schema.String,
@@ -18,6 +18,7 @@ export const OpenRouterRateLimitSchema = Schema.Struct({
   provider_name: Schema.NullOr(Schema.String)
 })
 
+/** @Schema.Effect.OpenRouter.ErrorBody */
 export const OpenRouterErrorBodySchema = Schema.Struct({
   error: Schema.Struct({
     message: Schema.String,
@@ -29,13 +30,14 @@ export const OpenRouterErrorBodySchema = Schema.Struct({
 
 export interface OpenRouterErrorBody extends Schema.Schema.Type<typeof OpenRouterErrorBodySchema> {}
 
-/** @Schema.Effect.OpenRouter.Response */
+/** @Schema.Effect.OpenRouter.Choice */
 export const ChoiceSchema = Schema.Struct({
   message: Schema.Struct({
     content: Schema.String
   })
 })
 
+/** @Schema.Effect.OpenRouter.Response */
 export const OpenRouterResponseSchema = Schema.Struct({
   choices: Schema.NonEmptyArray(ChoiceSchema)
 })
@@ -54,3 +56,41 @@ export const OpenRouterErrorCodes = {
 } as const
 
 export type OpenRouterErrorCode = keyof typeof OpenRouterErrorCodes
+
+/** @Schema.Effect.OpenRouter.UrlCitation */
+export const UrlCitationSchema = Schema.Struct({
+  url: Schema.String,
+  title: Schema.String,
+  content: Schema.optional(Schema.String),
+  start_index: Schema.Number,
+  end_index: Schema.Number
+})
+
+export type UrlCitation = Schema.Schema.Type<typeof UrlCitationSchema>
+
+/** @Schema.Effect.OpenRouter.Annotation */
+export const AnnotationSchema = Schema.Struct({
+  type: Schema.String,
+  url_citation: Schema.optional(UrlCitationSchema)
+})
+
+export type Annotation = Schema.Schema.Type<typeof AnnotationSchema>
+
+/** @Schema.Effect.OpenRouter.ToolCall */
+export const ToolCallSchema = Schema.Struct({
+  id: Schema.String,
+  name: Schema.String,
+  arguments: Schema.String
+})
+
+export type ToolCall = Schema.Schema.Type<typeof ToolCallSchema>
+
+/** @Schema.Effect.OpenRouter.ChatResponse */
+export const ChatResponseSchema = Schema.Struct({
+  content: Schema.String,
+  reasoning: Schema.optional(Schema.String),
+  annotations: Schema.optional(Schema.Array(AnnotationSchema)),
+  toolCalls: Schema.optional(Schema.Array(ToolCallSchema))
+})
+
+export type ChatResponse = Schema.Schema.Type<typeof ChatResponseSchema>

--- a/src/lib/effect/schemas/SuggestionSchema.ts
+++ b/src/lib/effect/schemas/SuggestionSchema.ts
@@ -1,0 +1,55 @@
+import { Schema } from "effect"
+import { ChatRole } from "@/types/chat"
+
+/** @Schema.Effect.Suggestion.FilterRule */
+export const FilterRuleSchema = Schema.Struct({
+  id: Schema.String,
+  check: Schema.declare(
+    (u): u is (s: string) => boolean => typeof u === "function",
+  ),
+})
+
+/** @Type.Effect.Suggestion.FilterRule */
+export type FilterRule = Schema.Schema.Type<typeof FilterRuleSchema>
+
+/** @Schema.Effect.Suggestion.Result */
+export const SuggestionResultSchema = Schema.Struct({
+  suggestion: Schema.String,
+  confidence: Schema.Number,
+})
+
+/** @Type.Effect.Suggestion.Result */
+export type SuggestionResult = Schema.Schema.Type<typeof SuggestionResultSchema>
+
+/** @Schema.Effect.Suggestion.Filter */
+export const SuggestionFilterSchema = Schema.Struct({
+  reason: Schema.String,
+  suggestion: Schema.NullOr(Schema.String),
+})
+
+/** @Type.Effect.Suggestion.Filter */
+export type SuggestionFilter = Schema.Schema.Type<typeof SuggestionFilterSchema>
+
+const ChatRoleSchema = Schema.Literal(
+  ChatRole.USER,
+  ChatRole.ASSISTANT,
+  ChatRole.SYSTEM,
+)
+
+/** @Schema.Effect.Suggestion.Message */
+export const SuggestionMessageSchema = Schema.Struct({
+  role: ChatRoleSchema,
+  content: Schema.String,
+})
+
+/** @Type.Effect.Suggestion.Message */
+export type SuggestionMessage = Schema.Schema.Type<typeof SuggestionMessageSchema>
+/** @Schema.Effect.Suggestion */
+export const SuggestionSchema = Schema.Struct({
+  label: Schema.String,
+  action: Schema.String,
+  icon: Schema.optional(Schema.String),
+})
+
+/** @Type.Effect.Suggestion */
+export type Suggestion = Schema.Schema.Type<typeof SuggestionSchema>

--- a/src/lib/effect/services/OpenRouter.ts
+++ b/src/lib/effect/services/OpenRouter.ts
@@ -1,4 +1,6 @@
-import { Effect, Stream, Option } from "effect"
+/** @Service.OpenRouter */
+
+import { Effect, Stream, Option, Context, Layer } from "effect"
 import { HttpClient, HttpClientRequest, HttpClientResponse } from "@effect/platform"
 import { ConfigService } from "./Config"
 import { PromptBuilderService } from "./PromptBuilder"
@@ -12,24 +14,33 @@ import { createSearchContext, createSearchMessage, getDiscoveryQuery } from "./s
 import type { Personalization } from "../schemas/PersonalizationSchema"
 import { SSEConstants } from "@/lib/constants/app-constants"
 import { HttpStatus } from "@/app/api/_lib/constants/status-codes"
+import { toolsToOpenRouter } from "./tools"
 
-export interface ChatResponse {
-  readonly content: string
-  readonly reasoning?: string
-  readonly annotations: readonly {
-    readonly type: string
-    readonly url_citation?: {
-      readonly url: string
-      readonly title: string
-      readonly content?: string
-      readonly start_index: number
-      readonly end_index: number
-    }
-  }[]
+import { ChatResponseSchema, type ChatResponse } from "../schemas/OpenRouterSchema"
+
+export const OpenRouter = Context.GenericTag<OpenRouter>("OpenRouter")
+
+export interface OpenRouter {
+  readonly chat: (
+    messages: ChatMessage[],
+    searchOptions?: PuertoRicoSearchOptions,
+    sessionId?: string,
+    personalization?: Personalization
+  ) => Stream.Stream<ChatResponse, OpenRouterError, I18n>
+  readonly searchPuertoRico: (
+    query: string,
+    options?: Partial<PuertoRicoSearchOptions>
+  ) => Stream.Stream<ChatResponse, OpenRouterError, I18n>
+  readonly discoverLive: (
+    category: DiscoveryCategory,
+    location?: string
+  ) => Stream.Stream<ChatResponse, OpenRouterError, I18n>
 }
 
-export class OpenRouter extends Effect.Service<OpenRouter>()("OpenRouter", {
-  effect: Effect.gen(function* () {
+/** @Layer.Effect.OpenRouter */
+export const OpenRouterLayer = Layer.effect(
+  OpenRouter,
+  Effect.gen(function* () {
     const baseClient = yield* HttpClient.HttpClient
     const config = yield* ConfigService
     const promptBuilder = yield* PromptBuilderService
@@ -42,28 +53,28 @@ export class OpenRouter extends Effect.Service<OpenRouter>()("OpenRouter", {
     }
 
     const chat = (
-      messages: readonly ChatMessage[],
+      messages: ChatMessage[],
       searchOptions?: PuertoRicoSearchOptions,
       sessionId?: string,
       personalization?: Personalization
     ): Stream.Stream<ChatResponse, OpenRouterError, I18n> => {
       const responseEffect = Effect.gen(function* () {
-        const i18n = yield* I18n
-        
-        const systemPrompt = buildSystemPrompt(i18n.t, searchOptions, personalization)
+        const t = (key: string, _params?: Record<string, string>) => key
+        const systemPrompt = buildSystemPrompt(t, searchOptions, personalization)
+
         const chatMessages = messages.filter(m => m.role !== "system")
         const enhancedMessages: ChatMessage[] = [
           { role: "system", content: systemPrompt },
           ...chatMessages
         ]
 
-        /** @Logic.Chat.BuildRequestBody */
         const requestBody: Record<string, unknown> = {
           model: config.models.default,
           messages: enhancedMessages,
           stream: config.chatRequestConfig.stream,
           temperature: config.chatRequestConfig.temperature,
           max_tokens: config.chatRequestConfig.maxTokens,
+          tools: toolsToOpenRouter(),
           provider: {
             allow_fallbacks: true,
             data_collection: "deny"
@@ -100,21 +111,28 @@ export class OpenRouter extends Effect.Service<OpenRouter>()("OpenRouter", {
         Stream.splitLines,
         Stream.filter((line) => line.startsWith(SSEConstants.DATA_PREFIX) && line !== SSEConstants.DATA_DONE),
         Stream.map((line) => line.slice(6)),
-        /** @Logic.Chat.ProcessStreamChunk.Simple */
         Stream.filterMap((jsonStr): Option.Option<ChatResponse> => {
           try {
-            const parsed = JSON.parse(jsonStr)
+            const parsed = JSON.parse(jsonStr as string)
             const content = parsed.choices?.[0]?.delta?.content || ""
-            /** @Logic.Chat.ExtractReasoning */
             const reasoning = parsed.choices?.[0]?.delta?.reasoning || ""
-            /** @Logic.OpenRouter.ExtractAnnotations */
             const annotations =
               parsed.choices?.[0]?.delta?.annotations ||
               parsed.choices?.[0]?.message?.annotations ||
               []
+            const toolCalls = parsed.choices?.[0]?.delta?.tool_calls || parsed.choices?.[0]?.message?.tool_calls || []
 
-            if (content || reasoning || annotations.length > 0) {
-              return Option.some({ content, reasoning: reasoning || undefined, annotations } as ChatResponse)
+            if (content || reasoning || annotations.length > 0 || toolCalls.length > 0) {
+              return Option.some({ 
+                content, 
+                reasoning: reasoning || undefined, 
+                annotations,
+                toolCalls: toolCalls.length > 0 ? toolCalls.map((tc: { id: string; function: { name: string; arguments: string } }) => ({
+                  id: tc.id,
+                  name: tc.function.name,
+                  arguments: tc.function.arguments
+                })) : undefined
+              } as ChatResponse)
             }
             return Option.none()
           } catch {
@@ -158,7 +176,6 @@ export class OpenRouter extends Effect.Service<OpenRouter>()("OpenRouter", {
       })
     }
 
-    return { chat, searchPuertoRico, discoverLive } as const
-  }),
-  accessors: true
-}) { }
+    return { chat, searchPuertoRico, discoverLive }
+  })
+)

--- a/src/lib/effect/services/Suggestion.ts
+++ b/src/lib/effect/services/Suggestion.ts
@@ -1,52 +1,63 @@
+import { Effect } from "effect"
 import type { ChatMessage, ChatRoleType } from "@/types/chat"
 import { ChatRole } from "@/types/chat"
+import { SuggestionError } from "@/lib/effect/errors"
+import type {
+  SuggestionResult,
+  SuggestionFilter,
+} from "@/lib/effect/schemas/SuggestionSchema"
 import { suggestionPrompt, suggestionSystemPrompt } from "./prompts/suggestion"
 import { SUGGESTION_FILTER_RULES, SUGGESTION_CONFIG } from "./prompts/suggestion-filters"
 
 /** @Config.Export */
 export { SUGGESTION_CONFIG }
 
-/** @Type.Result */
-export interface SuggestionResult {
-  readonly suggestion: string
-  readonly confidence: number
-}
+/** @Type.Export */
+export type { SuggestionResult, SuggestionFilter }
 
-/** @Type.Filter */
-export interface SuggestionFilter {
-  readonly reason: string
-  readonly suggestion: string | null
-}
-
-/** @Constant.RoleLabels */
+/** @Constant.Suggestion.RoleLabels */
 export const ROLE_LABELS: Record<ChatRoleType, string> = {
   [ChatRole.USER]: "Usuario",
   [ChatRole.ASSISTANT]: "Asistente",
   [ChatRole.SYSTEM]: "Sistema",
 } as const
 
-/** @Constant.ApiIndicator */
+/** @Constant.Suggestion.ApiIndicator */
 export const CHAT_ROLE_API_INDICATOR = "API" as const
 
-/** @Helper.GetRoleLabel */
+/** @Constant.Suggestion.GenerateTrigger */
+export const SUGGESTION_GENERATE_TOKEN = "[Generar sugerencia]" as const
+
+/** @Constant.Suggestion.ConversationSeparator */
+export const CONVERSATION_SEPARATOR = "--- CONVERSACIÓN ---" as const
+
+/** @Constant.Suggestion.ConversationEnd */
+export const CONVERSATION_END_MARKER = "---" as const
+
+/** @Helper.Suggestion.GetRoleLabel */
 function getRoleLabel(role: ChatRoleType): string {
   return ROLE_LABELS[role] ?? role
 }
 
-/** @Logic.ShouldShow */
+/** @Logic.Suggestion.ShouldShow */
 export function shouldShowSuggestion(messages: readonly ChatMessage[]): boolean {
-  /** @Logic.CountAssistants */
+  /** @Check.MinAssistantCount */
   const assistantCount = messages.filter((m) => m.role === ChatRole.ASSISTANT).length
   if (assistantCount < SUGGESTION_CONFIG.MIN_ASSISTANT_MESSAGES) return false
 
-  /** @Logic.FindLastAssistant */
+  /** @Check.ApiIndicator */
   const lastAssistant = messages.findLast((m) => m.role === ChatRole.ASSISTANT)
-  if (lastAssistant?.content?.toLowerCase().includes(CHAT_ROLE_API_INDICATOR.toLowerCase())) return false
+  if (
+    lastAssistant?.content
+      ?.toLowerCase()
+      .includes(CHAT_ROLE_API_INDICATOR.toLowerCase())
+  )
+    return false
 
   return true
 }
 
-/** @Logic.ShouldFilter */
+/** @Logic.Suggestion.ShouldFilter */
 export function shouldFilterSuggestion(suggestion: string | null): SuggestionFilter {
   /** @Check.Empty */
   if (!suggestion) return { reason: "empty", suggestion: null }
@@ -65,46 +76,52 @@ export function shouldFilterSuggestion(suggestion: string | null): SuggestionFil
   return { reason: "passed", suggestion: trimmed }
 }
 
-/** @Logic.Filter */
-export function filterSuggestion(suggestion: string | null): SuggestionFilter {
-  return shouldFilterSuggestion(suggestion)
-}
-
-/** @Logic.BuildPrompt */
+/** @Logic.Suggestion.BuildPrompt */
 export function buildSuggestionPrompt(messages: readonly ChatMessage[]): string {
-  /** @Logic.SliceHistory */
+  /** @Logic.Suggestion.SliceHistory */
   const conversationContext = messages
     .slice(-SUGGESTION_CONFIG.CONVERSATION_HISTORY_SIZE)
     .map((m) => {
-      /** @Logic.GetLabel */
+      /** @Logic.Suggestion.GetLabel */
       const role = getRoleLabel(m.role)
-      /** @Logic.TruncateContent */
+      /** @Logic.Suggestion.TruncateContent */
       const content = m.content?.slice(0, SUGGESTION_CONFIG.MAX_CONTEXT_LENGTH) || ""
       return `${role}: ${content}`
     })
     .join("\n\n")
 
-  return `${suggestionPrompt}\n\n--- CONVERSACIÓN ---\n${conversationContext}\n\n---`
+  return `${suggestionPrompt}\n\n${CONVERSATION_SEPARATOR}\n${conversationContext}\n\n${CONVERSATION_END_MARKER}`
 }
 
-/** @Logic.GetSystemPrompt */
+/** @Logic.Suggestion.GetSystemPrompt */
 export function getSuggestionSystemPrompt(): string {
   return suggestionSystemPrompt
 }
 
-/** @Logic.ProcessResponse */
-export function processSuggestionResponse(content: string): SuggestionResult {
-  /** @Logic.TrimContent */
+/** @Logic.Suggestion.ProcessResponse */
+export function processSuggestionResponse(
+  content: string,
+): Effect.Effect<SuggestionResult, SuggestionError> {
+  /** @Logic.Suggestion.TrimContent */
   const trimmed = content.trim()
-  /** @Logic.FilterContent */
+  /** @Logic.Suggestion.FilterContent */
   const filtered = shouldFilterSuggestion(trimmed)
 
   if (!filtered.suggestion) {
-    return { suggestion: "", confidence: 0 }
+    return Effect.fail(
+      new SuggestionError({
+        message: `Suggestion rejected by filter rule: ${filtered.reason}`,
+        reason: "filter",
+        filterReason: filtered.reason,
+      }),
+    )
   }
 
-  return {
+  return Effect.succeed({
     suggestion: filtered.suggestion,
     confidence: SUGGESTION_CONFIG.CONFIDENCE_THRESHOLD,
-  }
+  })
 }
+
+/** @Logic.Suggestion.FilterSuggestion */
+export const filterSuggestion = shouldFilterSuggestion

--- a/src/lib/effect/services/__tests__/Suggestion.test.ts
+++ b/src/lib/effect/services/__tests__/Suggestion.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest"
+import { Effect, Exit } from "effect"
 import {
   shouldShowSuggestion,
   shouldFilterSuggestion,
@@ -360,31 +361,38 @@ describe("Suggestion service", () => {
   })
 
   describe("processSuggestionResponse", () => {
+    /** @Helper.Test.Suggestion.RunSync */
+    const runSync = (input: string) =>
+      Exit.match(Effect.runSyncExit(processSuggestionResponse(input)), {
+        onSuccess: (r) => r,
+        onFailure: () => ({ suggestion: "", confidence: 0 }),
+      })
+
     it("should return filtered result for empty input", () => {
-      const result = processSuggestionResponse("")
+      const result = runSync("")
       expect(result.suggestion).toBe("")
       expect(result.confidence).toBe(0)
     })
 
     it("should return filtered result for whitespace only", () => {
-      const result = processSuggestionResponse("   ")
+      const result = runSync("   ")
       expect(result.suggestion).toBe("")
       expect(result.confidence).toBe(0)
     })
 
     it("should return result with confidence for valid suggestion", () => {
-      const result = processSuggestionResponse("Cuáles son las mejores playas?")
+      const result = runSync("Cuáles son las mejores playas?")
       expect(result.suggestion).toBe("Cuáles son las mejores playas?")
       expect(result.confidence).toBe(SUGGESTION_CONFIG.CONFIDENCE_THRESHOLD)
     })
 
     it("should trim suggestion before filtering", () => {
-      const result = processSuggestionResponse(" playitas del mar  ")
+      const result = runSync(" playitas del mar  ")
       expect(result.suggestion).toBe("playitas del mar")
     })
 
     it("should return empty for filtered suggestion", () => {
-      const result = processSuggestionResponse("gracias")
+      const result = runSync("gracias")
       expect(result.suggestion).toBe("")
       expect(result.confidence).toBe(0)
     })
@@ -401,7 +409,9 @@ describe("Suggestion service", () => {
     })
   })
 
+  /** @Test.Suggestion.EdgeCases */
   describe("Edge cases and bug prevention", () => {
+    /** @Test.Suggestion.ShouldShow.EdgeCases */
     describe("shouldShowSuggestion edge cases", () => {
       it("should handle only one assistant message", () => {
         const messages = [
@@ -459,6 +469,7 @@ describe("Suggestion service", () => {
       })
     })
 
+    /** @Test.Suggestion.ShouldFilter.EdgeCases */
     describe("shouldFilterSuggestion edge cases", () => {
       it("should handle whitespace-only string", () => {
         const result = shouldFilterSuggestion("   ")
@@ -585,6 +596,7 @@ describe("Suggestion service", () => {
       })
     })
 
+    /** @Test.Suggestion.BuildPrompt.EdgeCases */
     describe("buildSuggestionPrompt edge cases", () => {
       it("should handle messages with only system role", () => {
         const messages = [
@@ -620,6 +632,7 @@ describe("Suggestion service", () => {
       })
     })
 
+    /** @Test.Suggestion.Config.Constants */
     describe("SUGGESTION_CONFIG constants", () => {
       it("MIN_ASSISTANT_MESSAGES should be 2", () => {
         expect(SUGGESTION_CONFIG.MIN_ASSISTANT_MESSAGES).toBe(2)

--- a/src/lib/effect/services/prompts/suggestion-filters.ts
+++ b/src/lib/effect/services/prompts/suggestion-filters.ts
@@ -1,10 +1,19 @@
-/** @Type.FilterRule */
-export interface FilterRule {
-  readonly id: string
-  readonly check: (suggestion: string) => boolean
-}
+/** @Config.Suggestion.FilterRules */
 
-/** @Rule.FilterAll */
+import type { FilterRule } from "@/lib/effect/schemas/SuggestionSchema"
+
+/** @Constant.Suggestion.AllowedShortWords */
+export const ALLOWED_SHORT_WORDS = new Set([
+  "si",
+  "yes",
+  "no",
+  "ok",
+  "continuar",
+  "continue",
+  "gracias",
+] as const)
+
+/** @Constant.Suggestion.FilterRules */
 export const SUGGESTION_FILTER_RULES: FilterRule[] = [
   /** @Rule.Done */
   {
@@ -40,28 +49,19 @@ export const SUGGESTION_FILTER_RULES: FilterRule[] = [
     id: "too_few_words",
     check: (s) => {
       const words = s.trim().split(/\s+/)
-      if (words.length >= 2) return false
-      const ALLOWED = new Set([
-        "si",
-        "yes",
-        "no",
-        "ok",
-        "continuar",
-        "continue",
-        "gracias",
-      ])
-      return !ALLOWED.has(s.toLowerCase())
+      if (words.length >= SUGGESTION_CONFIG.MIN_WORDS) return false
+      return !ALLOWED_SHORT_WORDS.has(s.toLowerCase() as never)
     },
   },
   /** @Rule.TooManyWords */
   {
     id: "too_many_words",
-    check: (s) => s.trim().split(/\s+/).length > 12,
+    check: (s) => s.trim().split(/\s+/).length > SUGGESTION_CONFIG.MAX_WORDS,
   },
   /** @Rule.TooLong */
   {
     id: "too_long",
-    check: (s) => s.length >= 100,
+    check: (s) => s.length >= SUGGESTION_CONFIG.MAX_LENGTH,
   },
   /** @Rule.MultipleSentences */
   {
@@ -83,7 +83,10 @@ export const SUGGESTION_CONFIG = {
   CONVERSATION_HISTORY_SIZE: 6,
   MAX_CONTEXT_LENGTH: 200,
   CONFIDENCE_THRESHOLD: 0.7,
-  MIN_ASSISTANT_MESSAGES: 1,
-  /** @Config.RateLimit */
-  RATE_LIMIT_MS: 10000, // 10 seconds between requests
+  MIN_ASSISTANT_MESSAGES: 2,
+  /** @Config.Suggestion.RateLimit */
+  RATE_LIMIT_MS: 10_000,
 } as const
+
+/** @Type.Suggestion.Config */
+export type SuggestionConfig = typeof SUGGESTION_CONFIG

--- a/src/lib/effect/services/tools/executor.ts
+++ b/src/lib/effect/services/tools/executor.ts
@@ -1,0 +1,256 @@
+/** @Service.ToolExecutor */
+
+import { Effect, Schema } from "effect"
+import { getToolByName, isReadOnlyTool } from "./types"
+import { ToolError } from "../../errors"
+
+/** @Schema.ToolExecutionContext */
+export const ToolExecutionContextSchema = Schema.Struct({
+  toolName: Schema.String,
+  args: Schema.Record({ key: Schema.String, value: Schema.Unknown }),
+  startTime: Schema.Number
+})
+
+/** @Type.ToolExecutionContext */
+export interface ToolExecutionContext {
+  readonly toolName: string
+  readonly args: Record<string, unknown>
+  readonly startTime: number
+}
+
+/** @Schema.ToolPartitionResult */
+export const ToolPartitionResultSchema = Schema.Struct({
+  readOnly: Schema.Array(ToolExecutionContextSchema),
+  write: Schema.Array(ToolExecutionContextSchema)
+})
+
+/** @Type.ToolPartitionResult */
+export interface ToolPartitionResult {
+  readonly readOnly: ToolExecutionContext[]
+  readonly write: ToolExecutionContext[]
+}
+
+/** @Logic.PartitionTools */
+function partitionTools(toolCalls: Array<{ name: string; args: Record<string, unknown> }>): ToolPartitionResult {
+  const result: ToolPartitionResult = { readOnly: [], write: [] }
+  
+  for (const tc of toolCalls) {
+    const context: ToolExecutionContext = {
+      toolName: tc.name,
+      args: tc.args,
+      startTime: Date.now()
+    }
+    
+    if (isReadOnlyTool(tc.name)) {
+      result.readOnly.push(context)
+    } else {
+      result.write.push(context)
+    }
+  }
+  
+  return result
+}
+
+/** @Logic.ExecuteSingleTool */
+async function executeSingleTool(
+  toolName: string, 
+  args: Record<string, unknown>,
+  timeoutMs?: number,
+  retries?: number
+): Promise<string> {
+  const tool = getToolByName(toolName)
+  if (!tool) {
+    throw new Error(`Tool not found: ${toolName}`)
+  }
+  
+  const effectiveTimeout = timeoutMs ?? tool.timeoutMs ?? 30000
+  const maxRetries = retries ?? 0
+  const startTime = Date.now()
+  
+  let lastError: Error | undefined
+  
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      const result = await Effect.runPromise(
+        Effect.timeout(executeToolEffect(toolName, args), effectiveTimeout)
+      )
+      
+      recordMetric(toolName, attempt > 0, Date.now() - startTime)
+      return result
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error))
+      
+      if (attempt < maxRetries) {
+        const backoffMs = Math.min(1000 * Math.pow(2, attempt), 10000)
+        console.log(`[ToolRetry] ${toolName} failed, retrying in ${backoffMs}ms (attempt ${attempt + 1}/${maxRetries})`)
+        await new Promise(resolve => setTimeout(resolve, backoffMs))
+      }
+    }
+  }
+  
+  throw lastError || new Error(`Tool execution failed after ${maxRetries + 1} attempts`)
+}
+
+/** @Schema.ToolMetric */
+export const ToolMetricSchema = Schema.Struct({
+  toolName: Schema.String,
+  totalCalls: Schema.Number,
+  successfulCalls: Schema.Number,
+  failedCalls: Schema.Number,
+  totalLatencyMs: Schema.Number,
+  startTime: Schema.Number
+})
+
+/** @Type.ToolMetric */
+export interface ToolMetric {
+  readonly toolName: string
+  readonly totalCalls: number
+  readonly successfulCalls: number
+  readonly failedCalls: number
+  readonly totalLatencyMs: number
+  readonly startTime: number
+}
+
+const metricStore = new Map<string, ToolMetric>()
+
+/** @Logic.RecordMetric */
+function recordMetric(toolName: string, _wasRetry: boolean, latencyMs: number): void {
+  const existing = metricStore.get(toolName) || {
+    toolName,
+    totalCalls: 0,
+    successfulCalls: 0,
+    failedCalls: 0,
+    totalLatencyMs: 0,
+    startTime: Date.now()
+  }
+  
+  metricStore.set(toolName, {
+    ...existing,
+    totalCalls: existing.totalCalls + 1,
+    successfulCalls: existing.successfulCalls + 1,
+    totalLatencyMs: existing.totalLatencyMs + latencyMs
+  })
+}
+
+/** @Logic.RecordToolFailure */
+export function recordToolFailure(toolName: string): void {
+  const existing = metricStore.get(toolName) || {
+    toolName,
+    totalCalls: 0,
+    successfulCalls: 0,
+    failedCalls: 0,
+    totalLatencyMs: 0,
+    startTime: Date.now()
+  }
+  
+  metricStore.set(toolName, {
+    ...existing,
+    totalCalls: existing.totalCalls + 1,
+    failedCalls: existing.failedCalls + 1
+  })
+}
+
+/** @Logic.GetToolMetrics */
+export function getToolMetrics(): Record<string, { calls: number; success: number; failures: number; avgLatencyMs: number }> {
+  const result: Record<string, { calls: number; success: number; failures: number; avgLatencyMs: number }> = {}
+  
+  for (const [toolName, metric] of metricStore) {
+    result[toolName] = {
+      calls: metric.totalCalls,
+      success: metric.successfulCalls,
+      failures: metric.failedCalls,
+      avgLatencyMs: metric.totalCalls > 0 ? Math.round(metric.totalLatencyMs / metric.totalCalls) : 0
+    }
+  }
+  
+  return result
+}
+
+/** @Logic.ClearToolMetrics */
+export function clearToolMetrics(): void {
+  metricStore.clear()
+}
+
+/** @Logic.ExecuteToolEffect */
+function executeToolEffect(toolName: string, args: Record<string, unknown>): Effect.Effect<string, ToolError> {
+  return Effect.gen(function* () {
+    const tool = getToolByName(toolName)
+    if (!tool) {
+      return yield* Effect.fail(new ToolError({ toolName, message: `Tool not found: ${toolName}` }))
+    }
+    
+    const result = yield* executeWriteTool(toolName, args)
+    return result
+  })
+}
+
+/** @Logic.ExecuteWriteTool */
+function executeWriteTool(toolName: string, args: Record<string, unknown>): Effect.Effect<string, ToolError> {
+  switch (toolName) {
+    case "save_favorite": {
+      const { placeName, placeType, location, notes } = args as { 
+        placeName: string
+        placeType?: string
+        location?: string
+        notes?: string
+      }
+      return Effect.succeed(
+        `[TOOL_INVOKED] save_favorite saved: "${placeName}" (${placeType || 'place'}) at ${location || 'unspecified location'}. ` +
+        `Notes: ${notes || 'none'}. This will be persisted to user's favorites.`
+      )
+    }
+    case "save_itinerary": {
+      const { title, days, notes } = args as {
+        title: string
+        days?: Array<{ date: string; activities: Array<{ time: string; place: string; notes?: string }> }>
+        notes?: string
+      }
+      const dayCount = days?.length || 0
+      const activityCount = days?.reduce((sum, d) => sum + (d.activities?.length || 0), 0) || 0
+      return Effect.succeed(
+        `[TOOL_INVOKED] save_itinerary saved: "${title}" with ${dayCount} days and ${activityCount} activities. ` +
+        `Notes: ${notes || 'none'}. This will be persisted to user's itineraries.`
+      )
+    }
+    default:
+      return Effect.succeed(`[TOOL_INVOKED] ${toolName} with params: ${JSON.stringify(args)}`)
+  }
+}
+
+/** @Logic.ExecuteTool */
+export const executeTool = (toolName: string, args: Record<string, unknown>): Effect.Effect<string, ToolError> => {
+  return executeToolEffect(toolName, args)
+}
+
+/** @Logic.ExecuteToolsConcurrently */
+export const executeToolsConcurrently = async (
+  toolCalls: Array<{ name: string; args: Record<string, unknown> }>
+): Promise<Array<{ toolName: string; result: string; error?: string }>> => {
+  const partitioned = partitionTools(toolCalls)
+  const results: Array<{ toolName: string; result: string; error?: string }> = []
+  
+  if (partitioned.readOnly.length > 0) {
+    const readOnlyResults = await Promise.all(
+      partitioned.readOnly.map(async (ctx: ToolExecutionContext) => {
+        try {
+          const result = await executeSingleTool(ctx.toolName, ctx.args)
+          return { toolName: ctx.toolName, result, error: undefined }
+        } catch (e) {
+          return { toolName: ctx.toolName, result: '', error: String(e) }
+        }
+      })
+    )
+    results.push(...readOnlyResults)
+  }
+  
+  for (const ctx of partitioned.write) {
+    try {
+      const result = await executeSingleTool(ctx.toolName, ctx.args)
+      results.push({ toolName: ctx.toolName, result, error: undefined })
+    } catch (e) {
+      results.push({ toolName: ctx.toolName, result: '', error: String(e) })
+    }
+  }
+  
+  return results
+}

--- a/src/lib/effect/services/tools/index.ts
+++ b/src/lib/effect/services/tools/index.ts
@@ -1,0 +1,4 @@
+/** @Tools.Export */
+export * from "./schemas"
+export * from "./types"
+export * from "./executor"

--- a/src/lib/effect/services/tools/schemas.ts
+++ b/src/lib/effect/services/tools/schemas.ts
@@ -1,0 +1,85 @@
+/** @Schema.ToolParams */
+
+import { Schema } from "effect"
+
+const asSchema = <I, O, R>(s: Schema.Schema<I, O, R>): Schema.Schema<unknown, unknown, never> => s as Schema.Schema<unknown, unknown, never>
+
+/** @Schema.SearchBeachesParams */
+export const SearchBeachesParamsSchema = asSchema(Schema.Struct({
+  location: Schema.optional(Schema.String),
+  activity: Schema.optional(Schema.String)
+}))
+
+/** @Schema.SearchRestaurantsParams */
+export const SearchRestaurantsParamsSchema = asSchema(Schema.Struct({
+  cuisine: Schema.optional(Schema.String),
+  location: Schema.optional(Schema.String),
+  priceRange: Schema.optional(Schema.String)
+}))
+
+/** @Schema.SearchEventsParams */
+export const SearchEventsParamsSchema = asSchema(Schema.Struct({
+  category: Schema.optional(Schema.String),
+  location: Schema.optional(Schema.String),
+  date: Schema.optional(Schema.String)
+}))
+
+/** @Schema.SearchPlacesParams */
+export const SearchPlacesParamsSchema = asSchema(Schema.Struct({
+  category: Schema.optional(Schema.String),
+  location: Schema.optional(Schema.String)
+}))
+
+/** @Schema.SearchHotelsParams */
+export const SearchHotelsParamsSchema = asSchema(Schema.Struct({
+  location: Schema.optional(Schema.String),
+  budget: Schema.optional(Schema.String),
+  type: Schema.optional(Schema.String)
+}))
+
+/** @Schema.SearchWeatherParams */
+export const SearchWeatherParamsSchema = asSchema(Schema.Struct({
+  location: Schema.optional(Schema.String),
+  timeframe: Schema.optional(Schema.String)
+}))
+
+/** @Schema.SearchTransportParams */
+export const SearchTransportParamsSchema = asSchema(Schema.Struct({
+  from: Schema.optional(Schema.String),
+  to: Schema.optional(Schema.String),
+  mode: Schema.optional(Schema.String)
+}))
+
+/** @Schema.SaveFavoriteParams */
+export const SaveFavoriteParamsSchema = asSchema(Schema.Struct({
+  placeName: Schema.String,
+  placeType: Schema.optional(Schema.String),
+  location: Schema.optional(Schema.String),
+  notes: Schema.optional(Schema.String)
+}))
+
+/** @Schema.SaveItineraryParams */
+export const SaveItineraryParamsSchema = asSchema(Schema.Struct({
+  title: Schema.String,
+  days: Schema.optional(Schema.Array(Schema.Struct({
+    date: Schema.String,
+    activities: Schema.Array(Schema.Struct({
+      time: Schema.String,
+      place: Schema.String,
+      notes: Schema.optional(Schema.String)
+    }))
+  }))),
+  notes: Schema.optional(Schema.String)
+}))
+
+export const ToolParamsSchemas = {
+  search_beaches: SearchBeachesParamsSchema,
+  search_restaurants: SearchRestaurantsParamsSchema,
+  search_events: SearchEventsParamsSchema,
+  search_places: SearchPlacesParamsSchema,
+  search_hotels: SearchHotelsParamsSchema,
+  search_weather: SearchWeatherParamsSchema,
+  search_transport: SearchTransportParamsSchema,
+  save_favorite: SaveFavoriteParamsSchema,
+  save_itinerary: SaveItineraryParamsSchema
+} as const

--- a/src/lib/effect/services/tools/types.ts
+++ b/src/lib/effect/services/tools/types.ts
@@ -1,0 +1,173 @@
+/** @Schema.ToolDefinition */
+
+import { Schema, Either, pipe, JSONSchema } from "effect"
+import { ToolParamsSchemas } from "./schemas"
+
+/** @Schema.ToolInput */
+export const ToolInputSchema = Schema.Struct({
+  toolName: Schema.String,
+  args: Schema.Record({ key: Schema.String, value: Schema.Unknown })
+})
+
+/** @Type.ToolInput */
+export interface ToolInput {
+  readonly toolName: string
+  readonly args: Record<string, unknown>
+}
+
+/** @Type.ToolDefinition */
+export interface ToolDefinition {
+  readonly name: string
+  readonly description: string
+  readonly parameters: Schema.Schema<unknown, unknown, never>
+  readonly readOnly?: boolean
+  readonly shouldDefer?: boolean
+  readonly alwaysLoad?: boolean
+  readonly timeoutMs?: number
+  readonly isDestructive?: boolean
+  readonly searchHint?: string
+  readonly aliases?: string[]
+}
+
+/** @Tools.Priority.P0 */
+export const PUERTO_RICO_TOOLS: ToolDefinition[] = [
+  {
+    name: "search_beaches",
+    description: "Search for beaches in Puerto Rico by location, activities, or characteristics. Use this when users ask about beaches, swimming, surfing, snorkeling, or beach activities.",
+    parameters: ToolParamsSchemas.search_beaches,
+    readOnly: true,
+    alwaysLoad: true
+  },
+  {
+    name: "search_restaurants",
+    description: "Search for restaurants in Puerto Rico by cuisine, location, or price range. Use this when users ask about food, dining, local cuisine, or specific dishes.",
+    parameters: ToolParamsSchemas.search_restaurants,
+    readOnly: true,
+    alwaysLoad: true
+  },
+  {
+    name: "search_events",
+    description: "Search for events, festivals, concerts, and nightlife in Puerto Rico. Use this when users ask about what's happening, festivals, live music, or nightlife.",
+    parameters: ToolParamsSchemas.search_events,
+    readOnly: true,
+    alwaysLoad: true
+  },
+  {
+    name: "search_places",
+    description: "Search for general places, attractions, and things to do in Puerto Rico. Use this for general tourism questions about places to visit, attractions, or activities.",
+    parameters: ToolParamsSchemas.search_places,
+    readOnly: true,
+    alwaysLoad: true
+  },
+  {
+    name: "search_hotels",
+    description: "Search for accommodation in Puerto Rico including hotels, resorts, and rentals. Use this when users ask about where to stay, hotels, or lodging.",
+    parameters: ToolParamsSchemas.search_hotels,
+    readOnly: true,
+    alwaysLoad: true
+  },
+  {
+    name: "search_weather",
+    description: "Get weather information for Puerto Rico. Use this when users ask about weather, best time to visit, or current conditions.",
+    parameters: ToolParamsSchemas.search_weather,
+    readOnly: true,
+    alwaysLoad: true
+  },
+  {
+    name: "search_transport",
+    description: "Get transportation information for Puerto Rico. Use this for how to get around, car rental, public transport, or directions.",
+    parameters: ToolParamsSchemas.search_transport,
+    readOnly: true,
+    alwaysLoad: true,
+    searchHint: "transportation options"
+  },
+  {
+    name: "save_favorite",
+    description: "Save a place to the user's favorites list. Use this when user wants to save or bookmark a place they liked.",
+    parameters: ToolParamsSchemas.save_favorite,
+    readOnly: false,
+    alwaysLoad: true,
+    isDestructive: false,
+    searchHint: "save favorite place"
+  },
+  {
+    name: "save_itinerary",
+    description: "Save a trip itinerary for the user's travel plans. Use this when user wants to save their travel plan or schedule.",
+    parameters: ToolParamsSchemas.save_itinerary,
+    readOnly: false,
+    alwaysLoad: true,
+    isDestructive: false,
+    searchHint: "save travel itinerary"
+  }
+]
+
+/** @Tools.Export */
+export const TOOLS = PUERTO_RICO_TOOLS
+
+const toolSchemaCacheRef = { current: new Map<string, unknown>() }
+
+/** @Tools.GetCachedSchema */
+export function getCachedToolSchema(toolName: string): unknown | undefined {
+  return toolSchemaCacheRef.current.get(toolName)
+}
+
+/** @Tools.SetCachedSchema */
+export function setCachedToolSchema(toolName: string, schema: unknown): void {
+  toolSchemaCacheRef.current.set(toolName, schema)
+}
+
+/** @Tools.ClearCache */
+export function clearToolSchemaCache(): void {
+  toolSchemaCacheRef.current.clear()
+}
+
+/** @Tools.GetByName */
+export function getToolByName(name: string): ToolDefinition | undefined {
+  return PUERTO_RICO_TOOLS.find(t => t.name === name)
+}
+
+/** @Tools.IsReadOnly */
+export function isReadOnlyTool(name: string): boolean {
+  const tool = getToolByName(name)
+  return tool?.readOnly ?? false
+}
+
+/** @Tools.ToOpenRouterFormat */
+export function toolsToOpenRouter(): unknown {
+  return PUERTO_RICO_TOOLS.map(tool => {
+    const cached = getCachedToolSchema(tool.name)
+    if (cached) {
+      return cached
+    }
+    
+    const jsonSchema = JSONSchema.make(tool.parameters)
+    const schema = {
+      type: "function",
+      function: {
+        name: tool.name,
+        description: tool.description,
+        parameters: jsonSchema
+      }
+    }
+    
+    setCachedToolSchema(tool.name, schema)
+    return schema
+  })
+}
+
+/** @Tools.ValidateInput */
+export function validateToolInput(toolName: string, args: unknown): { success: boolean; parsed?: Record<string, unknown>; error?: string } {
+  const tool = getToolByName(toolName)
+  if (!tool) {
+    return { success: false, error: `Tool not found: ${toolName}` }
+  }
+
+  const result = Schema.decodeUnknownEither(tool.parameters)(args)
+  return pipe(
+    result,
+    Either.match({
+      onLeft: (left: unknown) => ({ success: false, error: `Invalid arguments for ${toolName}: ${left}` }),
+      onRight: (right: unknown) => ({ success: true, parsed: right as Record<string, unknown> })
+    })
+  )
+}

--- a/src/store/slices/chatSlice.ts
+++ b/src/store/slices/chatSlice.ts
@@ -1,7 +1,9 @@
 import { createSlice } from '@reduxjs/toolkit';
 import type { PayloadAction } from '@reduxjs/toolkit';
+import { castDraft } from 'immer';
 import type { ChatMessage, AdaptiveData, Suggestion, SearchResult } from '@/types/chat';
 import { ChatRole } from '@/types/chat';
+
 
 /** @Type.Chat */
 export interface Chat {
@@ -81,11 +83,11 @@ export const chatSlice = createSlice({
     },
     /** @Store.Action.Chat.SetMessages */
     setMessages: (state, action: PayloadAction<ChatMessage[]>) => {
-      state.messages = action.payload;
+      state.messages = castDraft(action.payload);
     },
     /** @Store.Action.Chat.AddMessage */
     addMessage: (state, action: PayloadAction<ChatMessage>) => {
-      state.messages.push(action.payload);
+      state.messages.push(castDraft(action.payload));
     },
     /** @Store.Action.Chat.UpdateLastMessage */
     updateLastMessage: (state, action: PayloadAction<string | { content?: string; metadata?: ChatMessage['metadata'] }>) => {
@@ -96,10 +98,10 @@ export const chatSlice = createSlice({
         } else {
           if (action.payload.content !== undefined) last.content = action.payload.content;
           if (action.payload.metadata !== undefined) {
-            last.metadata = { 
-              ...last.metadata, 
-              ...action.payload.metadata 
-            };
+            last.metadata = castDraft({
+              ...last.metadata,
+              ...action.payload.metadata,
+            });
           }
         }
       }
@@ -120,6 +122,7 @@ export const chatSlice = createSlice({
     setActiveAdaptiveData: (state, action: PayloadAction<AdaptiveData[]>) => {
       state.activeAdaptiveData = action.payload;
     },
+    /** @Store.Action.Chat.AddActiveAdaptiveData */
     addActiveAdaptiveData: (state, action: PayloadAction<AdaptiveData>) => {
       state.activeAdaptiveData.push(action.payload);
     },

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -1,46 +1,30 @@
-import type { CardType } from '@/lib/effect/schemas/AdaptiveCardsSchema';
+/** @Type.Chat */
 
-export type { CardType };
+export type {
+  SearchResult,
+  ChatMessageMetadata,
+  ChatMessage,
+  MessageStep,
+  ToolCallRecord,
+} from '@/lib/effect/schemas/ChatSchema'
 
-export interface SearchResult {
-  title: string;
-  url: string;
-  snippet?: string;
-  source?: string;
-  icon?: string;
-  verified?: boolean;
-}
+import type { CardType } from '@/lib/effect/schemas/AdaptiveCardsSchema'
 
+/** @Type.Chat.CardType */
+export type { CardType }
+
+/** @Constant.Chat.Role */
 export const ChatRole = {
   USER: 'user',
   ASSISTANT: 'assistant',
-  SYSTEM: 'system'
-} as const;
+  SYSTEM: 'system',
+} as const
 
-export type ChatRoleType = typeof ChatRole[keyof typeof ChatRole];
+/** @Type.Chat.RoleType */
+export type ChatRoleType = (typeof ChatRole)[keyof typeof ChatRole]
 
-export interface ChatMessage {
-  role: ChatRoleType;
-  content: string;
-  metadata?: {
-    thought?: string;
-    thoughtTime?: string;
-    isThinking?: boolean;
-    thoughtDuration?: string;
-    steps?: { type: 'analyzed' | 'plan' | 'search'; label: string }[];
-    sources?: SearchResult[];
-    searchQuery?: string;
-    edited?: boolean;
-  };
-}
+/** @Type.Chat.Suggestion */
+export type { Suggestion } from '@/lib/effect/schemas/SuggestionSchema'
 
-export interface Suggestion {
-  label: string;
-  action: string;
-  icon?: string;
-}
-
-export interface AdaptiveData {
-  type: CardType;
-  data: unknown;
-}
+/** @Type.Chat.AdaptiveData */
+export type { AdaptiveData } from '@/lib/effect/schemas/AdaptiveCardsSchema'


### PR DESCRIPTION
## Summary

- Implement tool calling with 9 tools (7 search + 2 write)
- Add agentic loop with retry logic and exponential backoff
- Add tool executor with metrics and concurrency support
- Add Effect Schema for ChatResponse, ToolCall, Annotation types
- Add tool_calls display in MessageBubble UI
- Fix TypeScript and lint errors

## Changes

- New: `src/lib/effect/schemas/ChatSchema.ts`, `SuggestionSchema.ts`
- New: `src/lib/effect/services/tools/` (executor, types, schemas, index)
- Modified: route.ts (agentic loop), MessageBubble.tsx (UI), OpenRouter.ts
- Tests: 92 passing

## Issue

Closes #112